### PR TITLE
Added dynamic and metadata environment

### DIFF
--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -67,6 +67,19 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+      env:
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: MY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        {{- range $key, $value := .Values.slave.env }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+        {{- end }}
       volumes:
         - name: proc
           hostPath:

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -96,6 +96,19 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+      env:
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: MY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        {{- range $key, $value := .Values.master.env }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+        {{- end }}
       volumes:
         - name: config
           configMap:

--- a/values.yaml
+++ b/values.yaml
@@ -46,6 +46,8 @@ master:
 
   affinity: {}
 
+  env: {}
+
   database:
     storageclass: "standard"
     volumesize: 2Gi
@@ -71,7 +73,8 @@ slave:
 
   affinity: {}
 
+  env: {}
+
 notifications:
   slackurl: ""
   slackrecipient: ""
-


### PR DESCRIPTION
I have added the ability to add environment variables into values.yaml. Now you can add new environment variables in values.yaml or set up them with --set flag, also I have added couple meta information in environment variables about a pod name and namespace.

Example: 
`helm install --name netdata ./ --dry-run --debug --set master.env.LOG_LEVEL=debug,master.env.PORT=80`

```
...
      env:
        - name: MY_POD_NAME
          valueFrom:
            fieldRef:
              fieldPath: metadata.name
        - name: MY_POD_NAMESPACE
          valueFrom:
            fieldRef:
              fieldPath: metadata.namespace
        - name: LOG_LEVEL
          value: "debug"
        - name: PORT
          value: "80"
...
```
*p.s. variables LOG_LEVEL and PORT are fictional*
