### PR TITLE
Changed rbac

### DIFF
--- a/templates/clusterrole.yaml
+++ b/templates/clusterrole.yaml
@@ -6,8 +6,8 @@ rules:
 - apiGroups: [""]
   resources: ["services", "events", "endpoints", "pods", "nodes", "componentstatuses"]
   verbs: ["get", "list", "watch"]
-- apiGroups: ["quota.openshift.io"]
-  resources: ["clusterresourcequotas"]
+- apiGroups: [""]
+  resources: ["resourcequotas"]
   verbs: ["get", "list"]
 - nonResourceURLs:
   - "/version"


### PR DESCRIPTION
I think this will not work in Kubernetes. `apiGroups: ["quota.openshift.io"]` is API group only in OpenShift