### PR TITLE
Extend configuration file support and update README

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 name: netdata
 home: https://github.com/netdata/netdata
-version: 0.0.5
+version: 0.0.6
 appVersion: v1.13.0
 description: Real-time performance monitoring, done right! https://my-netdata.io/
 maintainer:

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -9,22 +9,9 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  stream.conf: |-
-    [stream]
-        enabled = yes
-        destination = {{ template "netdata.name" . }}:{{ .Values.service.port }}
-        api key = {{ .Values.APIKEY }}
-        timeout seconds = 60
-        buffer size bytes = 1048576
-        reconnect delay seconds = 5
-        initial clock resync iterations = 60
-  netdata.conf: |-
-    [global]
-        memory mode = ram
-    [web]
-        mode = none
-    [health]
-        enabled = no
+  netdata.conf: {{ toYaml .Values.slave.netdata_config | indent 4 }}
+  stream.conf: {{ toYaml .Values.slave.stream_config | indent 4 }}
+
 ---
 
 apiVersion: v1
@@ -37,26 +24,15 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  stream.conf: |-
-    [{{ .Values.APIKEY }}]
-        enabled = yes
-        history = 3600
-        default memory mode = save
-        health enabled by default = auto
-        allow from = *
-  netdata.conf: |-
-    [global]
-        memory mode = save
-        bind to = 0.0.0.0:{{ .Values.service.port }}
-  health_alarm_notify.conf: |- # The following is an example. You will need to configure and start the sendmail daemon to use it, or use a different notification method
-        SEND_EMAIL="NO"
-        SEND_SLACK="YES"
-        SLACK_WEBHOOK_URL="{{ .Values.notifications.slackurl }}"
-        DEFAULT_RECIPIENT_SLACK="{{ .Values.notifications.slackrecipient }}"
-        role_recipients_slack[sysadmin]="${DEFAULT_RECIPIENT_SLACK}"
-        role_recipients_slack[domainadmin]="${DEFAULT_RECIPIENT_SLACK}"
-        role_recipients_slack[dba]="${DEFAULT_RECIPIENT_SLACK}"
-        role_recipients_slack[webmaster]="${DEFAULT_RECIPIENT_SLACK}"
-        role_recipients_slack[proxyadmin]="${DEFAULT_RECIPIENT_SLACK}"
-        role_recipients_slack[sitemgr]="${DEFAULT_RECIPIENT_SLACK}"
+  netdata.conf: {{ toYaml .Values.master.netdata_config | indent 4 }}
+  stream.conf: {{ toYaml .Values.master.stream_config | indent 4 }}
+  health_alarm_notify.conf: {{ toYaml .Values.master.health_config | indent 4 }}
+  example.conf: |-
+    alarm: example_alarm1
+      on: example.random
+    every: 2s
+    warn: $random1 > (($status >= $WARNING)  ? (70) : (80))
+    crit: $random1 > (($status == $CRITICAL) ? (80) : (90))
+    info: random
+      to: sysadmin
 

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -78,6 +78,9 @@ spec:
             - name: health
               mountPath: /etc/netdata/health_alarm_notify.conf
               subPath: health_alarm_notify.conf
+            - name: alarms-example
+              mountPath: /etc/netdata/health.d/example.conf
+              subPath: example.conf
             - name: database
               mountPath: /var/cache/netdata
             - name: alarms
@@ -128,3 +131,9 @@ spec:
             items:
               - key: health_alarm_notify.conf
                 path: health_alarm_notify.conf
+        - name: alarms-example
+          configMap:
+            name: netdata-conf-master
+            items:
+              - key: example.conf
+                path: example.conf

--- a/values.yaml
+++ b/values.yaml
@@ -28,7 +28,6 @@ serviceaccount:
 clusterrole:
   name: netdata
 
-APIKEY: 11111111-2222-3333-4444-555555555555
 
 master:
   resources: {}
@@ -55,6 +54,34 @@ master:
     storageclass: "standard"
     volumesize: 100Mi
 
+  # stream.conf
+  stream_config: |-
+    [11111111-2222-3333-4444-555555555555]
+      enabled = yes
+      history = 3600
+      default memory mode = save
+      health enabled by default = auto
+      allow from = *
+
+  # netdata.conf
+  netdata_config: |-
+    [global]
+      memory mode = save
+      bind to = 0.0.0.0:19999
+
+  # health_alarm_notify.conf
+  health_config: |-
+    SEND_EMAIL="NO"
+    SEND_SLACK="YES"
+    SLACK_WEBHOOK_URL=""
+    DEFAULT_RECIPIENT_SLACK=""
+    role_recipients_slack[sysadmin]="${DEFAULT_RECIPIENT_SLACK}"
+    role_recipients_slack[domainadmin]="${DEFAULT_RECIPIENT_SLACK}"
+    role_recipients_slack[dba]="${DEFAULT_RECIPIENT_SLACK}"
+    role_recipients_slack[webmaster]="${DEFAULT_RECIPIENT_SLACK}"
+    role_recipients_slack[proxyadmin]="${DEFAULT_RECIPIENT_SLACK}"
+    role_recipients_slack[sitemgr]="${DEFAULT_RECIPIENT_SLACK}"
+
 slave:
   resources: {}
     # limits:
@@ -72,8 +99,25 @@ slave:
 
   affinity: {}
 
+  # netdata.conf
+  netdata_config: |-
+    [global]
+      memory mode = ram
+    [web]
+      mode = none
+    [health]
+      enabled = no
+
+  # stream.conf
+  stream_config: |-
+    [stream]
+      enabled = yes
+      destination = netdata:19999
+      api key = 11111111-2222-3333-4444-555555555555
+      timeout seconds = 60
+      buffer size bytes = 1048576
+      reconnect delay seconds = 5
+      initial clock resync iterations = 60
+
   env: {}
 
-notifications:
-  slackurl: ""
-  slackrecipient: ""


### PR DESCRIPTION
Related to #1 

- Moved standard config contents to values.yaml
- Added sample example alarm configuration for the master
- Updated README, also with instructions on how to add more config files.