### PR TITLE
Add preStop to ensure graceful shut down gracefully before the pod is removed

### DIFF
--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -34,6 +34,10 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh","-c","killall netdata; while killall -0 netdata; do sleep 1; done"]
           volumeMounts:
             - name: proc
               readOnly: true

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -48,6 +48,10 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh","-c","killall netdata; while killall -0 netdata; do sleep 1; done"] 
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}


### PR DESCRIPTION
References:
https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/
https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
