### PR TITLE
Disable plugins from the master

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 name: netdata
 home: https://github.com/netdata/netdata
-version: 0.0.6
+version: 0.0.7
 appVersion: v1.13.0
 description: Real-time performance monitoring, done right! https://my-netdata.io/
 maintainer:

--- a/values.yaml
+++ b/values.yaml
@@ -68,6 +68,16 @@ master:
     [global]
       memory mode = save
       bind to = 0.0.0.0:19999
+    [plugins]
+      cgroups = no
+      tc = no
+      enable running new plugins = no
+      check for new plugins every = 72000
+      python.d = no
+      charts.d = no
+      go.d = no
+      node.d = no
+      apps = yes
 
   # health_alarm_notify.conf
   health_config: |-


### PR DESCRIPTION
Leave only the bare minimum collectors on the master, it's the slaves that do the work. 