### PR TITLE
* Fix RBAC. ClusterRoleBinding installed SeviceAccount only from name…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# IntelliJ project files
+.idea
+*.iml
+out
+gen

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -6,3 +6,5 @@ description: Real-time performance monitoring, done right! https://my-netdata.io
 maintainer:
   name: Chris Akritidis
   email: chris@netdata.cloud
+  name: Vladimir Ryumin
+  email: vryumin@gmail.com

--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ Parameter | Description | Default
 `ingress.annotations` | Associate annotations to the Ingress | `kubernetes.io/ingress.class: nginx` and `kubernetes.io/tls-acme: "true"`
 `ingress.path` | URL path for the ingress | `/`
 `ingress.hosts` | URL hostnames for the ingress (they need to resolve to the external IP of the ingress controller) | `netdata.k8s.local`
-`serviceaccount.name` | Name of the service account that provides access rights  to netdata | `netdata`
+`rbac.create` | if true, create & use RBAC resources | `true`
+`serviceAccount.create` |if true, create a service account | `true`
+`serviceAccount.name` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template. | `netdata`
 `clusterrole.name` | Name of the cluster role linked with the service account | `netdata`
 `APIKEY` | The key shared between the master and the slave netdata for streaming | `11111111-2222-3333-4444-555555555555`
 `master.resources` | Resources for the master statefulset | `{}`

--- a/templates/clusterrole.yaml
+++ b/templates/clusterrole.yaml
@@ -1,7 +1,13 @@
+{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Values.clusterrole.name }}
+  name: {{ template "netdata.fullname" . }}
+  labels:
+    app: {{ template "netdata.name" . }}
+    chart: {{ template "netdata.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 rules:
 - apiGroups: [""]
   resources: ["services", "events", "endpoints", "pods", "nodes", "componentstatuses", "nodes/proxy" ]
@@ -17,3 +23,4 @@ rules:
 - apiGroups: [""]
   resources: ["nodes/metrics", "nodes/spec"]
   verbs: ["get"]
+{{- end -}}

--- a/templates/clusterrolebinding.yaml
+++ b/templates/clusterrolebinding.yaml
@@ -1,12 +1,19 @@
+{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: netdata
+  name: {{ template "netdata.fullname" . }}
+  labels:
+    app: {{ template "netdata.name" . }}
+    chart: {{ template "netdata.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Values.clusterrole.name }}
+  name: {{ template "netdata.fullname" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.serviceaccount.name }}
-  namespace: default
+  name: {{ .Values.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -25,7 +25,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
-      serviceAccountName: {{ .Values.serviceaccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
       restartPolicy: Always
       hostPID: true
       hostIPC: true

--- a/templates/serviceaccount.yaml
+++ b/templates/serviceaccount.yaml
@@ -1,5 +1,11 @@
+{{- if .Values.serviceAccount.create -}}
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: {{ .Values.serviceaccount.name }}
-  namespace: default
+  labels:
+    app: {{ template "netdata.name" . }}
+    chart: {{ template "netdata.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name: {{ .Values.serviceAccount.name }}
+{{- end -}}

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -43,7 +43,7 @@ spec:
     spec:
       securityContext:
         fsGroup: 201
-      serviceAccountName: {{ .Values.serviceaccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -58,7 +58,7 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /
+              path: /api/v1/info
               port: http
             timeoutSeconds: 1
             periodSeconds: 30
@@ -66,7 +66,7 @@ spec:
             failureThreshold: 3
           readinessProbe:
             httpGet:
-              path: /
+              path: /api/v1/info
               port: http
             timeoutSeconds: 1
             periodSeconds: 30

--- a/values.yaml
+++ b/values.yaml
@@ -22,10 +22,11 @@ ingress:
 #      hosts:
 #        - netdata.k8s.local
 
-serviceaccount:
-  name: netdata
+rbac:
+  create: true
 
-clusterrole:
+serviceAccount:
+  create: true
   name: netdata
 
 


### PR DESCRIPTION
* Fix RBAC. `ClusterRoleBinding` can use `SeviceAccount` only from namespace `default`. If you installed in another namespace ("not `default`") then `ServiceAccount` and `ClusterRoleBinding` didn't work
* Feature RBAC. You can pick between "turn on" (`helm ... -set rbac.create=true`) or "turn off" (`helm ... -set rbac.create=false`) RBAC.
* Feature RBAC. You can create serviceAccount or use your existing `serviceAccount`.
* I have changed liveness and readiness probes on `/api/v1/info`
* Added myself to Chart.yaml (if you don't mind @cakrit )