### PR TITLE
add sysctl init container

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 name: netdata
 home: https://github.com/netdata/netdata
-version: 0.0.9
+version: 0.0.10
 appVersion: v1.13.0
 description: Real-time performance monitoring, done right! https://my-netdata.io/
 maintainer:

--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ Parameter | Description | Default
 `master.netdata_config` | Contents of the slave's `netdata.conf` | No persistent storage, no alarms, no UI
 `notifications.slackurl` | URL for slack notifications | `""`
 `notifications.slackrecipient` | Slack recipient list | `""`
+`sysctlImage.enabled` | Enable an init container to modify Kernel settings | `false` |
+`sysctlImage.command` | sysctlImage command to execute | [] |
+`sysctlImage.repository`| sysctlImage Init container name | `alpine` |
+`sysctlImage.tag` | sysctlImage Init container tag | `latest` |
+`sysctlImage.pullPolicy` | sysctlImage Init container pull policy | `Always` |
+`sysctlImage.resources` | sysctlImage Init container CPU/Memory resource requests/limits | {} |
 
 Example to set the parameters from the command line:
 ```console

--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -30,6 +30,19 @@ spec:
       hostPID: true
       hostIPC: true
       hostNetwork: true
+      initContainers:
+      {{- if .Values.sysctlImage.enabled }}
+        - name: init-sysctl
+          image: "{{ .Values.sysctlImage.repository }}:{{ .Values.sysctlImage.tag }}"
+          command:
+{{ toYaml .Values.sysctlImage.command | indent 12 }}
+          securityContext:
+            runAsNonRoot: false
+            privileged: true
+            runAsUser: 0
+          resources:
+{{ toYaml .Values.sysctlImage.resources | indent 12 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -45,6 +45,19 @@ spec:
       securityContext:
         fsGroup: 201
       serviceAccountName: {{ .Values.serviceAccount.name }}
+      initContainers:
+      {{- if .Values.sysctlImage.enabled }}
+        - name: init-sysctl
+          image: "{{ .Values.sysctlImage.repository }}:{{ .Values.sysctlImage.tag }}"
+          command:
+{{ toYaml .Values.sysctlImage.command | indent 12 }}
+          securityContext:
+            runAsNonRoot: false
+            privileged: true
+            runAsUser: 0
+          resources:
+{{ toYaml .Values.sysctlImage.resources | indent 12 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/values.yaml
+++ b/values.yaml
@@ -5,6 +5,13 @@ image:
   tag: v1.13.0
   pullPolicy: Always
 
+sysctlImage:
+  enabled: false
+  repository: alpine
+  tag: latest
+  pullPolicy: Always
+  command: []
+
 service:
   type: ClusterIP
   port: 19999


### PR DESCRIPTION
Hi,

I need to set `vm.max_map_count` sysctl param to bypass the `Cannot allocate memory` issue. So I added the init container, where sysctl params could be managed.

Thanks