### PR TITLE
Slave liveness probe and memory mode none, use netdata v1.14

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 name: netdata
 home: https://github.com/netdata/netdata
-version: 0.0.10
-appVersion: v1.13.0
+version: 0.0.11
+appVersion: v1.14.0
 description: Real-time performance monitoring, done right! https://my-netdata.io/
 maintainer:
   name: Chris Akritidis

--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -54,6 +54,26 @@ spec:
             preStop:
               exec:
                 command: ["/bin/sh","-c","killall netdata; while killall -0 netdata; do sleep 1; done"]
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /api/v1/info
+              port: http
+            timeoutSeconds: 1
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /api/v1/info
+              port: http
+            timeoutSeconds: 1
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 3
           volumeMounts:
             - name: proc
               readOnly: true

--- a/values.yaml
+++ b/values.yaml
@@ -120,9 +120,7 @@ slave:
   # netdata.conf
   netdata_config: |-
     [global]
-      memory mode = ram
-    [web]
-      mode = none
+      memory mode = none
     [health]
       enabled = no
 


### PR DESCRIPTION
- Use netdata v1.14.0
- Add liveness/readiness probe on slaves (enable web server to do it)
- Make slaves run in memory mode none

Fixes #16.