### PR TITLE
Correct another wrong parameter name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Parameter | Description | Default
 `slave.affinity` | Affinity settings for the slave daemonsets | `{}`
 `slave.env` | Set environment parameters for the slave daemonset | `{}`
 `slave.stream_config` | Contents of the slave `stream.conf` | Send metrics to the master at netdata:19999
-`master.netdata_config` | Contents of the slave's `netdata.conf` | No persistent storage, no alarms, no UI
+`slave.netdata_config` | Contents of the slave's `netdata.conf` | No persistent storage, no alarms, no UI
 `notifications.slackurl` | URL for slack notifications | `""`
 `notifications.slackrecipient` | Slack recipient list | `""`
 `sysctlImage.enabled` | Enable an init container to modify Kernel settings | `false` |


### PR DESCRIPTION
Just caught up another typo in the readme while tinkering with the chart.
Edited to correspond with:
https://github.com/netdata/helmchart/blob/c72a62e2f6095e4f222d026f7272d8cda26d1967/templates/configmap.yaml#L12