### PR TITLE
k8s monitoring configuration

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 name: netdata
 home: https://github.com/netdata/netdata
-version: 0.0.11
+version: 0.0.14
 appVersion: v1.14.0
 description: Real-time performance monitoring, done right! https://my-netdata.io/
 maintainer:

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 name: netdata
 home: https://github.com/netdata/netdata
-version: 0.0.14
+version: 0.0.12
 appVersion: v1.14.0
 description: Real-time performance monitoring, done right! https://my-netdata.io/
 maintainer:

--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ Parameter | Description | Default
 `slave.env` | Set environment parameters for the slave daemonset | `{}`
 `slave.stream_config` | Contents of the slave `stream.conf` | Send metrics to the master at netdata:19999
 `slave.netdata_config` | Contents of the slave's `netdata.conf` | No persistent storage, no alarms, no UI
+`slave.coredns_config` | Contents of the slave's `go.d/coredns.conf` that drives the coredns collector | Update metrics every sec, do not retry to detect the endpoint, look for the coredns metrics at http://127.0.0.1:9153/metrics
+`slave.kubelet_config` | Contents of the slave's `go.d/k8s_kubelet.conf` that drives the kubelet collector | Update metrics every sec, do not retry to detect the endpoint, look for the kubelet metrics at http://127.0.0.1:10255/metrics
+`slave.kubeproxy_config` | Contents of the slave's `go.d/k8s_kubeproxy.conf` that drives the kubeproxy collector | Update metrics every sec, do not retry to detect the endpoint, look for the coredns metrics at http://127.0.0.1:10249/metrics
 `notifications.slackurl` | URL for slack notifications | `""`
 `notifications.slackrecipient` | Slack recipient list | `""`
 `sysctlImage.enabled` | Enable an init container to modify Kernel settings | `false` |

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -11,6 +11,9 @@ metadata:
 data:
   netdata.conf: {{ toYaml .Values.slave.netdata_config | indent 4 }}
   stream.conf: {{ toYaml .Values.slave.stream_config | indent 4 }}
+  coredns.conf: {{ toYaml .Values.slave.coredns_config | indent 4 }}
+  k8s_kubelet.conf: {{ toYaml .Values.slave.kubelet_config | indent 4 }}
+  k8s_kubeproxy.conf: {{ toYaml .Values.slave.kubeproxy_config | indent 4 }}
 
 ---
 

--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -88,6 +88,15 @@ spec:
             - name: stream
               mountPath: /etc/netdata/stream.conf
               subPath: stream.conf
+            - name: coredns
+              mountPath: /etc/netdata/go.d/coredns.conf
+              subPath: coredns.conf
+            - name: kubelet
+              mountPath: /etc/netdata/go.d/k8s_kubelet.conf
+              subPath: k8s_kubelet.conf
+            - name: kubeproxy
+              mountPath: /etc/netdata/go.d/k8s_kubeproxy.conf
+              subPath: k8s_kubeproxy.conf
           securityContext:
             capabilities:
               add:
@@ -142,4 +151,22 @@ spec:
             items:
               - key: stream.conf
                 path: stream.conf
+        - name: coredns
+          configMap:
+            name: netdata-conf-slave
+            items:
+              - key: coredns.conf
+                path: coredns.conf
+        - name: kubelet
+          configMap:
+            name: netdata-conf-slave
+            items:
+              - key: k8s_kubelet.conf
+                path: k8s_kubelet.conf
+        - name: kubeproxy
+          configMap:
+            name: netdata-conf-slave
+            items:
+              - key: k8s_kubeproxy.conf
+                path: k8s_kubeproxy.conf
       dnsPolicy: ClusterFirstWithHostNet

--- a/values.yaml
+++ b/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: netdata/netdata
-  tag: v1.13.0
+  tag: v1.14.0
   pullPolicy: Always
 
 sysctlImage:
@@ -70,6 +70,7 @@ master:
       default memory mode = save
       health enabled by default = auto
       allow from = *
+    
 
   # netdata.conf
   netdata_config: |-
@@ -86,6 +87,7 @@ master:
       go.d = no
       node.d = no
       apps = yes
+    
 
   # health_alarm_notify.conf
   health_config: |-
@@ -99,6 +101,7 @@ master:
     role_recipients_slack[webmaster]="${DEFAULT_RECIPIENT_SLACK}"
     role_recipients_slack[proxyadmin]="${DEFAULT_RECIPIENT_SLACK}"
     role_recipients_slack[sitemgr]="${DEFAULT_RECIPIENT_SLACK}"
+    
 
 slave:
   resources: {}
@@ -123,6 +126,7 @@ slave:
       memory mode = none
     [health]
       enabled = no
+    
 
   # stream.conf
   stream_config: |-
@@ -134,6 +138,31 @@ slave:
       buffer size bytes = 1048576
       reconnect delay seconds = 5
       initial clock resync iterations = 60
+      
+
+  # go.d/coredns.conf
+  coredns_config: |-
+    update_every: 1
+    autodetection_retry: 0
+    jobs:
+      - url: http://127.0.0.1:9153/metrics
+      
+
+  # go.d/k8s_kubelet.conf
+  kubelet_config: |-
+    update_every: 1
+    autodetection_retry: 0
+    jobs:
+      - url: http://127.0.0.1:10255/metrics
+      
+
+  # go.d/k8s_kubeproxy.conf
+  kubeproxy_config: |-
+    update_every: 1
+    autodetection_retry: 0
+    jobs:
+      - url: http://127.0.0.1:10249/metrics
+      
 
   env: {}
 


### PR DESCRIPTION
Fixes #21 

The stock configs already enabled k8s monitoring for kubelet, kubeproxy and coredns, but added the option of overriding the settings in values.yaml. 

Other minor changes in this PR:
- Add a newline at the end of each config file (actually with some spaces on the last line too, but I couldn't find a way to avoid it).
- Fix the tag in values.yaml to v1.14.0