### PR TITLE
Persistence toggle and fixes

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: netdata
 home: https://github.com/netdata/netdata
-version: 0.0.12
+version: 0.0.13
 appVersion: v1.14.0
 description: Real-time performance monitoring, done right! https://my-netdata.io/
 maintainers:

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,10 +1,13 @@
+apiVersion: v1
 name: netdata
 home: https://github.com/netdata/netdata
 version: 0.0.12
 appVersion: v1.14.0
 description: Real-time performance monitoring, done right! https://my-netdata.io/
-maintainer:
-  name: Chris Akritidis
-  email: chris@netdata.cloud
-  name: Vladimir Ryumin
-  email: vryumin@gmail.com
+maintainers:
+  - name: Chris Akritidis
+    email: chris@netdata.cloud
+  - name: Vladimir Ryumin
+    email: vryumin@gmail.com
+  - name: Karuppiah Natarajan
+    email: karuppiah7890@gmail.com

--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -47,6 +47,19 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            {{- range $key, $value := .Values.slave.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
           lifecycle:
             postStart:
               exec:
@@ -116,19 +129,6 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
-      env:
-        - name: MY_POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: MY_POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        {{- range $key, $value := .Values.slave.env }}
-        - name: {{ $key }}
-          value: {{ $value | quote }}
-        {{- end }}
       volumes:
         - name: proc
           hostPath:

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -68,6 +68,19 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            {{- range $key, $value := .Values.master.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
           lifecycle:
             preStop:
               exec:
@@ -130,19 +143,6 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
-      env:
-        - name: MY_POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: MY_POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        {{- range $key, $value := .Values.master.env }}
-        - name: {{ $key }}
-          value: {{ $value | quote }}
-        {{- end }}
       volumes:
         - name: config
           configMap:

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -11,15 +11,19 @@ metadata:
 spec:
   serviceName: {{ template "netdata.name" . }}
   replicas: {{ .Values.replicaCount }}
+  {{- if or .Values.master.database.persistence .Values.master.alarms.persistence }}
   volumeClaimTemplates:
+  {{- if .Values.master.database.persistence }}
     - metadata:
         name: database
       spec:
         accessModes: [ "ReadWriteOnce" ]
-        storageClassName: {{ .Values.master.alarms.storageclass }}
+        storageClassName: {{ .Values.master.database.storageclass }}
         resources:
           requests:
             storage: {{ .Values.master.database.volumesize }}
+  {{- end }}
+  {{- if .Values.master.alarms.persistence }}
     - metadata:
         name: alarms
       spec:
@@ -28,6 +32,8 @@ spec:
         resources:
           requests:
             storage: {{ .Values.master.alarms.volumesize }}
+  {{- end }}
+  {{- end }}
   selector:
     matchLabels:
       app: {{ template "netdata.name" . }}
@@ -68,7 +74,7 @@ spec:
                 command: ["/bin/sh","-c","python -c 'import uuid; import socket; print(uuid.uuid3(uuid.NAMESPACE_DNS, socket.gethostname()))' > /var/lib/netdata/registry/netdata.public.unique.id"]
             preStop:
               exec:
-                command: ["/bin/sh","-c","killall netdata; while killall -0 netdata; do sleep 1; done"] 
+                command: ["/bin/sh","-c","killall netdata; while killall -0 netdata; do sleep 1; done"]
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}
@@ -102,10 +108,14 @@ spec:
             - name: alarms-example
               mountPath: /etc/netdata/health.d/example.conf
               subPath: example.conf
+            {{- if .Values.master.database.persistence }}
             - name: database
               mountPath: /var/cache/netdata
+            {{- end }}
+            {{- if .Values.master.alarms.persistence }}
             - name: alarms
               mountPath: /var/lib/netdata
+            {{- end }}
           resources:
 {{ toYaml .Values.master.resources | indent 12 }}
     {{- with .Values.master.nodeSelector }}

--- a/values.yaml
+++ b/values.yaml
@@ -55,10 +55,12 @@ master:
   env: {}
 
   database:
+    persistence: true
     storageclass: "standard"
     volumesize: 2Gi
 
   alarms:
+    persistence: true
     storageclass: "standard"
     volumesize: 100Mi
 


### PR DESCRIPTION
Fixes #17 and #25 

Summary of the features and fixes
1. Support toggling of persistence volumes for database and alarms
2. Fix `master.alarms.storageclass` being used for claiming volume for database too
3. Add apiVersion in Chart.yaml as it's required in helm3 and canary version of helm2 also shows linting error for the same
4. Fix `maintainers` key in Chart.yaml
5. Fix env field being in pod spec instead of inside container spec, in both DaemonSet and StatefulSet

cc @cakrit @varyumin . Please review 😄 