### PR TITLE
Allow custom labels and annotations to be set on pods.

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: netdata
 home: https://github.com/netdata/netdata
-version: 1.0.1
+version: 1.1.0
 appVersion: v1.15.0
 description: Real-time performance monitoring, done right! https://my-netdata.io/
 maintainers:

--- a/README.md
+++ b/README.md
@@ -83,12 +83,16 @@ Parameter | Description | Default
 `master.alarms.storageclass` | The storage class for the persistent volume claim of the master's alarm log, mounted to `/var/lib/netdata` | `standard`
 `master.alarms.volumesize` | The storage space for the PVC of the master alarm log | `100Mi`
 `master.env` | Set environment parameters for the master statefulset | `{}`
+`master.podLabels` | Additional labels to add to the master pods | `{}`
+`master.podAnnotations` | Additional annotations to add to the master pods | `{}`
 `master.configs` | Manage custom master's configs | See [Configuration files](#configuration-files).
 `slave.resources` | Resources for the slave daemonsets | `{}`
 `slave.nodeSelector` | Node selector for the slave daemonsets | `{}`
 `slave.tolerations` | Tolerations settings for the slave daemonsets | `- operator: Exists` with `effect: NoSchedule`
 `slave.affinity` | Affinity settings for the slave daemonsets | `{}`
 `slave.env` | Set environment parameters for the slave daemonset | `{}`
+`slave.podLabels` | Additional labels to add to the slave pods | `{}`
+`slave.podAnnotations` | Additional annotations to add to the slave pods | `{}`
 `slave.configs` | Manage custom slave's configs | See [Configuration files](#configuration-files).
 `notifications.slackurl` | URL for slack notifications | `""`
 `notifications.slackrecipient` | Slack recipient list | `""`
@@ -152,3 +156,19 @@ must be indented with two more spaces relative to the preceding line:
         config line 2 #No problem indenting more here
 ```
 
+### Custom pod labels and annotations
+
+Occasionally, you will want to add specific [labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) and [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) to the master and/or slave pods.
+You might want to do this to tell other applications on the cluster how to treat your pods, or simply to categorize applications on your cluster.
+You can label and annotate the master and slave pods by using the `podLabels` and `podAnnotations` dictionaries under the `master` and `slave` objects, respectively.
+
+For example, suppose you're installing netdata on all your database nodes, and you'd like the slave pods to be labeled with `workload: database` so that you're able to recognize this.
+At the same time, say you've configured [chaoskube](https://github.com/helm/charts/tree/master/stable/chaoskube) to kill all pods annotated with `chaoskube.io/enabled: true`, and you'd like chaoskube to be enabled for the master pod but not the slaves.
+You would do this by installing as:
+
+```console
+$ helm install ./netdata --name my-release \
+    --set slave.podLabels.workload=database \
+    --set 'slave.podAnnotations.chaoskube\.io/enabled=false' \
+    --set 'master.podAnnotations.chaoskube\.io/enabled=true'
+```

--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -22,8 +22,14 @@ spec:
         app: {{ template "netdata.name" . }}
         release: {{ .Release.Name }}
         role: slave
+{{- with .Values.slave.podLabels }}
+{{ toYaml . | trim | indent 8 }}
+{{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+{{- with .Values.slave.podAnnotations }}
+{{ toYaml . | trim | indent 8 }}
+{{- end }}
     spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}
       restartPolicy: Always

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -45,8 +45,14 @@ spec:
         app: {{ template "netdata.name" . }}
         release: {{ .Release.Name }}
         role: master
+{{- with .Values.master.podLabels }}
+{{ toYaml . | trim | indent 8 }}
+{{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+{{- with .Values.master.podAnnotations }}
+{{ toYaml . | trim | indent 8 }}
+{{- end }}
     spec:
       securityContext:
         fsGroup: 201

--- a/values.yaml
+++ b/values.yaml
@@ -54,6 +54,10 @@ master:
 
   env: {}
 
+  podLabels: {}
+
+  podAnnotations: {}
+
   database:
     persistence: true
     storageclass: "standard"
@@ -134,6 +138,10 @@ slave:
       effect: NoSchedule
 
   affinity: {}
+
+  podLabels: {}
+
+  podAnnotations: {}
 
   configs:
     netdata:


### PR DESCRIPTION
This will allow the master and slave pods to be labeled and annotated
with user-defined values, in addition to the default labels and
annotations included in the chart.

closes #33