### PR TITLE
Upgrade version and remove all charts from the master

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: netdata
 home: https://github.com/netdata/netdata
-version: 1.1.0
-appVersion: v1.15.0
+version: 1.1.1
+appVersion: v1.16.0
 description: Real-time performance monitoring, done right! https://my-netdata.io/
 maintainers:
   - name: Chris Akritidis

--- a/values.yaml
+++ b/values.yaml
@@ -95,7 +95,10 @@ master:
           charts.d = no
           go.d = no
           node.d = no
-          apps = yes
+          apps = no
+          proc = no
+          idlejitter = no
+          diskspace = no
     health:
       enabled: true
       path: /etc/netdata/health_alarm_notify.conf


### PR DESCRIPTION
Use 1.16.0
Disable remaining plugins, as the master isn't meant to be monitoring anything, just maintains the DB.