### PR TITLE
Move apparmor annotation to pod template

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: netdata
 home: https://github.com/netdata/netdata
-version: 1.1.1
+version: 1.1.2
 appVersion: v1.16.0
 description: Real-time performance monitoring, done right! https://my-netdata.io/
 maintainers:

--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -1,8 +1,6 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  annotations:
-    container.apparmor.security.beta.kubernetes.io/netdata-slave: unconfined
   name: {{ template "netdata.name" . }}-slave
   labels:
     app: {{ template "netdata.name" . }}
@@ -18,6 +16,8 @@ spec:
       role: slave
   template:
     metadata:
+      annotations:
+        container.apparmor.security.beta.kubernetes.io/netdata-slave: unconfined
       labels:
         app: {{ template "netdata.name" . }}
         release: {{ .Release.Name }}


### PR DESCRIPTION
Based on examples here: https://kubernetes.io/docs/tutorials/clusters/apparmor/ I think this annotation needs to be on the pods themselves to get through PSP checks.