### PR TITLE
Correctly set DaemonSet AppArmor annotation

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: netdata
 home: https://github.com/netdata/netdata
-version: 1.1.2
+version: 1.1.3
 appVersion: v1.16.0
 description: Real-time performance monitoring, done right! https://my-netdata.io/
 maintainers:

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Parameter | Description | Default
 `slave.env` | Set environment parameters for the slave daemonset | `{}`
 `slave.podLabels` | Additional labels to add to the slave pods | `{}`
 `slave.podAnnotations` | Additional annotations to add to the slave pods | `{}`
+`slave.podAnnotationAppArmor.enabled` | Whether or not to include the AppArmor security annotation | `true`
 `slave.configs` | Manage custom slave's configs | See [Configuration files](#configuration-files).
 `notifications.slackurl` | URL for slack notifications | `""`
 `notifications.slackrecipient` | Slack recipient list | `""`

--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -17,17 +17,18 @@ spec:
   template:
     metadata:
       annotations:
+      {{- if .Values.slave.podAnnotationAppArmor.enabled }}
         container.apparmor.security.beta.kubernetes.io/netdata-slave: unconfined
+      {{- end }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+{{- with .Values.slave.podAnnotations }}
+{{ toYaml . | trim | indent 8 }}
+{{- end }}
       labels:
         app: {{ template "netdata.name" . }}
         release: {{ .Release.Name }}
         role: slave
 {{- with .Values.slave.podLabels }}
-{{ toYaml . | trim | indent 8 }}
-{{- end }}
-      annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-{{- with .Values.slave.podAnnotations }}
 {{ toYaml . | trim | indent 8 }}
 {{- end }}
     spec:

--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -18,7 +18,7 @@ spec:
     metadata:
       annotations:
       {{- if .Values.slave.podAnnotationAppArmor.enabled }}
-        container.apparmor.security.beta.kubernetes.io/netdata-slave: unconfined
+        container.apparmor.security.beta.kubernetes.io/{{ .Chart.Name }}: unconfined
       {{- end }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{- with .Values.slave.podAnnotations }}

--- a/values.yaml
+++ b/values.yaml
@@ -144,6 +144,9 @@ slave:
 
   podLabels: {}
 
+  podAnnotationAppArmor:
+    enabled: true
+
   podAnnotations: {}
 
   configs:


### PR DESCRIPTION
In https://github.com/netdata/helmchart/commit/c0fa186ddcbd9be488309dbffb85d9f57b521ab8 I missed that there was an existing annotations block.

This also makes the AppArmor annotation configurable (though on by default).

Fixes https://github.com/netdata/helmchart/issues/40

Signed-off-by: Charlie Egan <charlieegan3@users.noreply.github.com>