### PR TITLE
Statefulset api version is now apps/v1

### DIFF
--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "netdata.name" . }}-master


### PR DESCRIPTION
In kubernetes v1.16 the deprecated `apps/v1beta2` for StatefulSet is removed [1].
Deployment is failing with:
```
microk8s.helm install --name my-release ./netdata
Error: validation failed: unable to recognize "": no matches for kind "StatefulSet" in version "apps/v1beta2"
```

[1] https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/