### PR TITLE
Use by default the default storage class for PVCs

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,10 @@ Parameter | Description | Default
 `master.tolerations` | Tolerations settings for the master statefulset | `[]`
 `master.affinity` | Affinity settings for the master statefulset | `{}`
 `master.database.persistence` | Whether the master should use a persistent volume for the DB | `true`
-`master.database.storageclass` | The storage class for the persistent volume claim of the master's database store, mounted to `/var/cache/netdata` | `standard`
+`master.database.storageclass` | The storage class for the persistent volume claim of the master's database store, mounted to `/var/cache/netdata` | the default storage class
 `master.database.volumesize` | The storage space for the PVC of the master database | `2Gi`
 `master.alarms.persistence` | Whether the master should use a persistent volume for the alarms log | `true`
-`master.alarms.storageclass` | The storage class for the persistent volume claim of the master's alarm log, mounted to `/var/lib/netdata` | `standard`
+`master.alarms.storageclass` | The storage class for the persistent volume claim of the master's alarm log, mounted to `/var/lib/netdata` | the default storage class
 `master.alarms.volumesize` | The storage space for the PVC of the master alarm log | `100Mi`
 `master.env` | Set environment parameters for the master statefulset | `{}`
 `master.podLabels` | Additional labels to add to the master pods | `{}`

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -18,7 +18,9 @@ spec:
         name: database
       spec:
         accessModes: [ "ReadWriteOnce" ]
-        storageClassName: {{ .Values.master.database.storageclass }}
+      {{- if (ne "-" .Values.master.database.storageclass) }}
+        storageClassName: "{{ .Values.master.database.storageclass }}"
+      {{- end }}
         resources:
           requests:
             storage: {{ .Values.master.database.volumesize }}
@@ -28,7 +30,9 @@ spec:
         name: alarms
       spec:
         accessModes: [ "ReadWriteOnce" ]
-        storageClassName: {{ .Values.master.alarms.storageclass }}
+      {{- if (ne "-" .Values.master.alarms.storageclass) }}
+        storageClassName: "{{ .Values.master.alarms.storageclass }}"
+      {{- end }}
         resources:
           requests:
             storage: {{ .Values.master.alarms.volumesize }}

--- a/values.yaml
+++ b/values.yaml
@@ -61,12 +61,14 @@ master:
 
   database:
     persistence: true
-    storageclass: "standard"
+    # Set '-' as the storageclass to get a volume from the default storage class.
+    storageclass: "-"
     volumesize: 2Gi
 
   alarms:
     persistence: true
-    storageclass: "standard"
+    # Set '-' as the storageclass to get a volume from the default storage class.
+    storageclass: "-"
     volumesize: 100Mi
 
   configs:


### PR DESCRIPTION
I think using the default storage class is a more sane default value for the `storageclass`.

Also, since the empty string as storage class has a special meaning we use "-" to denote the absence of storageclass (resulting to selecting the default storageclass) [1]

[1] https://github.com/helm/helm/issues/2600