### PR TITLE
Optionally disable daemonset

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Parameter | Description | Default
 `master.podLabels` | Additional labels to add to the master pods | `{}`
 `master.podAnnotations` | Additional annotations to add to the master pods | `{}`
 `master.configs` | Manage custom master's configs | See [Configuration files](#configuration-files).
+`slave.enabled` | Install slave daemonset to gather data from nodes | `true`
 `slave.resources` | Resources for the slave daemonsets | `{}`
 `slave.nodeSelector` | Node selector for the slave daemonsets | `{}`
 `slave.tolerations` | Tolerations settings for the slave daemonsets | `- operator: Exists` with `effect: NoSchedule`

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ on a  [Kubernetes](http://kubernetes.io) cluster using the
 [Helm](https://helm.sh) package manager.
 
 The chart installs a netdata slave pod on each node of a cluster, using a 
-`Daemonset` and a netdata master pod on one node, using a `Statefulset`. The slaves function as headless collectors that simply collect and forward all the metrics to the master netdata. The master uses persistent volumes to store metrics and alarms, handles alarm notifications and provides the netdata UI to view the metrics, using an ingress controller.
+`Daemonset` if not disabled, and a netdata master pod on one node, using a `Statefulset`. The slaves function as headless collectors that simply collect and forward all the metrics to the master netdata. The master uses persistent volumes to store metrics and alarms, handles alarm notifications and provides the netdata UI to view the metrics, using an ingress controller.
 
 ## Prerequisites
   - Kubernetes 1.9+

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.slave.enabled -}}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -14,6 +15,7 @@ data:
   {{ $name }}: {{ toYaml $config.data | indent 4 }}
   {{- end }}
   {{- end }}
+{{- end }}
 
 ---
 apiVersion: v1

--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.slave.enabled -}}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -139,3 +140,4 @@ spec:
           configMap:
             name: netdata-conf-slave
       dnsPolicy: ClusterFirstWithHostNet
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -129,6 +129,7 @@ master:
           to: sysadmin
 
 slave:
+  enabled: true
   resources: {}
     # limits:
     #  cpu: 4


### PR DESCRIPTION
**Reasoning:**   
I'd like to install only master with this helmchart via helmfile together with rest of the components which are installed with helmfile. Currently I have to template chart with helm and remove slave configmap and daemonset files. I run netdata (close to our prometheus instance which is then scraping the netdata) in managed K8s cluster where I don't have possibility to access worker nodes data as those have their own managed monitoring solution so there's no reason to deploy the slave daemonset. I'd like to use it as streaming master for netdata instances running in openstack VMs.