### PR TITLE
ingress.yaml: change the yaml to ref the new API

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "netdata.name" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
 
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}


### PR DESCRIPTION
Reference: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/