### PR TITLE
netdata-slave: add MY_NODE_NAME env var

### DIFF
--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -60,6 +60,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: MY_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             - name: MY_POD_NAMESPACE
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
This PR adds `MY_NODE_NAME` env var to the netdata-slave daemonset. It allows us to use `fieldSelect` query parameter doing `api/v1/pods` call. We dont need to query pods for the whole cluster, we need to query all pods for the specific node.


Docs:
> https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#list-all-namespaces-pod-v1-core

Cgroup-name.sh script:

https://github.com/netdata/netdata/blob/fce6650a689625f3a591cf79046395b62c9687f9/collectors/cgroups.plugin/cgroup-name.sh.in#L89-L110

___

available since 1.4 (https://github.com/kubernetes/kubernetes/pull/27880)