### PR TITLE
add slave netdata.public.unique.id persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Parameter | Description | Default
 `slave.podLabels` | Additional labels to add to the slave pods | `{}`
 `slave.podAnnotations` | Additional annotations to add to the slave pods | `{}`
 `slave.podAnnotationAppArmor.enabled` | Whether or not to include the AppArmor security annotation | `true`
+`slave.persistUniqueID` | Whether or not to persist `netdata.public.unique.id` across restarts | `true`
 `slave.configs` | Manage custom slave's configs | See [Configuration files](#configuration-files).
 `notifications.slackurl` | URL for slack notifications | `""`
 `notifications.slackrecipient` | Slack recipient list | `""`

--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -52,11 +52,11 @@ spec:
 {{ toYaml .Values.sysctlImage.resources | indent 12 }}
       {{- end }}
         {{- if .Values.slave.persistUniqueID }}
-        - name: init-nodeuniqueid
+        - name: init-nodeuid
           image: busybox
           volumeMounts:
-            - name: nodeuniqueid
-              mountPath: "/nodeuniqueid"
+            - name: nodeuid
+              mountPath: "/nodeuid"
           env:
             - name: MY_NODE_NAME
               valueFrom:
@@ -77,7 +77,7 @@ spec:
             UID=$(echo "${DATA}" | grep -m 1 uid | grep -o ":.*," | tr -d ": \",");
             [ -z "${UID}" ] && exit 1;
 
-            echo -n "${UID}" > /nodeuniqueid/netdata.public.unique.id;
+            echo -n "${UID}" > /nodeuid/netdata.public.unique.id;
             '
       {{- end }}
       containers:
@@ -137,7 +137,7 @@ spec:
             {{- end }}
             {{- end }}
             {{- if .Values.slave.persistUniqueID }}
-            - name: nodeuniqueid
+            - name: nodeuid
               mountPath: "/var/lib/netdata/registry/"
             {{- end }}
           securityContext:
@@ -173,7 +173,7 @@ spec:
           configMap:
             name: netdata-conf-slave
         {{- if .Values.slave.persistUniqueID }}
-        - name: nodeuniqueid
+        - name: nodeuid
           emptyDir: {}
         {{- end }}
       dnsPolicy: ClusterFirstWithHostNet

--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -51,6 +51,35 @@ spec:
           resources:
 {{ toYaml .Values.sysctlImage.resources | indent 12 }}
       {{- end }}
+        {{- if .Values.slave.persistUniqueID }}
+        - name: init-nodeuniqueid
+          image: busybox
+          volumeMounts:
+            - name: nodeuniqueid
+              mountPath: "/nodeuniqueid"
+          env:
+            - name: MY_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          command:
+            - "/bin/sh"
+          args:
+            - "-c"
+            - '
+            TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token);
+            URL="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/api/v1/nodes/${MY_NODE_NAME}";
+            HEADER="Authorization: Bearer ${TOKEN}";
+
+            DATA=$(wget -q -T 5 --no-check-certificate --header "${HEADER}" -O - "${URL}");
+            [ -z "${DATA}" ] && exit 1;
+
+            UID=$(echo "${DATA}" | grep -m 1 uid | grep -o ":.*," | tr -d ": \",");
+            [ -z "${UID}" ] && exit 1;
+
+            echo "${UID}" > /nodeuniqueid/netdata.public.unique.id;
+            '
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -60,6 +89,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: MY_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             - name: MY_POD_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -107,6 +140,10 @@ spec:
               subPath: {{ $name }}
             {{- end }}
             {{- end }}
+            {{- if .Values.slave.persistUniqueID }}
+            - name: nodeuniqueid
+              mountPath: "/var/lib/netdata/registry/"
+            {{- end }}
           securityContext:
             capabilities:
               add:
@@ -139,5 +176,9 @@ spec:
         - name: config
           configMap:
             name: netdata-conf-slave
+        {{- if .Values.slave.persistUniqueID }}
+        - name: nodeuniqueid
+          emptyDir: {}
+        {{- end }}
       dnsPolicy: ClusterFirstWithHostNet
 {{- end }}

--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -77,7 +77,7 @@ spec:
             UID=$(echo "${DATA}" | grep -m 1 uid | grep -o ":.*," | tr -d ": \",");
             [ -z "${UID}" ] && exit 1;
 
-            echo "${UID}" > /nodeuniqueid/netdata.public.unique.id;
+            echo -n "${UID}" > /nodeuniqueid/netdata.public.unique.id;
             '
       {{- end }}
       containers:

--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -74,7 +74,10 @@ spec:
             DATA=$(wget -q -T 5 --no-check-certificate --header "${HEADER}" -O - "${URL}");
             [ -z "${DATA}" ] && exit 1;
 
-            UID=$(echo "${DATA}" | grep -m 1 uid | grep -o ":.*," | tr -d ": \",");
+            UID=$(echo "${DATA}" | grep -m 1 systemUUID | grep -o ":.*" | tr -d ": \",");
+            if [ -z "${UID}" ]; then
+              UID=$(echo "${DATA}" | grep -m 1 uid | grep -o ":.*" | tr -d ": \",");
+            fi
             [ -z "${UID}" ] && exit 1;
 
             echo -n "${UID}" > /nodeuid/netdata.public.unique.id;

--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -74,10 +74,7 @@ spec:
             DATA=$(wget -q -T 5 --no-check-certificate --header "${HEADER}" -O - "${URL}");
             [ -z "${DATA}" ] && exit 1;
 
-            UID=$(echo "${DATA}" | grep -m 1 systemUUID | grep -o ":.*" | tr -d ": \",");
-            if [ -z "${UID}" ]; then
-              UID=$(echo "${DATA}" | grep -m 1 uid | grep -o ":.*" | tr -d ": \",");
-            fi
+            UID=$(echo "${DATA}" | grep -m 1 uid | grep -o ":.*" | tr -d ": \",");
             [ -z "${UID}" ] && exit 1;
 
             echo -n "${UID}" > /nodeuid/netdata.public.unique.id;

--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -89,10 +89,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            - name: MY_NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
             - name: MY_POD_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/values.yaml
+++ b/values.yaml
@@ -11,6 +11,7 @@ sysctlImage:
   tag: latest
   pullPolicy: Always
   command: []
+  resources: {}
 
 service:
   type: ClusterIP
@@ -34,7 +35,7 @@ ingress:
 rbac:
   create: true
   pspEnabled: true
-  
+
 serviceAccount:
   create: true
   name: netdata
@@ -156,6 +157,8 @@ slave:
     enabled: true
 
   podAnnotations: {}
+
+  persistUniqueID: true
 
   configs:
     netdata:


### PR DESCRIPTION
Fixes: #61

This PR adds persistence of netdata slaves `netdata.public.unique.id` value. 

When this PR is merged netdata slaves will use local node `metadata.uid` as `netdata.public.unique.id`.

___

I tested this feauture on GKE.

All slaves/nodes:
```cmd
$ kubectl get pods --selector=app=netdata --selector=role=slave -o wide
NAME                  READY   STATUS    RESTARTS   AGE   IP            NODE                                                NOMINATED NODE   READINESS GATES
netdata-slave-ltmfg   1/1     Running   0          31m   10.128.0.32   gke-standard-cluster-2-default-pool-86353fdd-b7zb   <none>           <none>
netdata-slave-rcrkj   1/1     Running   0          31m   10.128.0.31   gke-standard-cluster-2-default-pool-86353fdd-494b   <none>           <none>
netdata-slave-tqhdt   1/1     Running   0          31m   10.128.0.33   gke-standard-cluster-2-default-pool-86353fdd-t45s   <none>           <none>
```

Slave1:
```cmd
$ kubectl get nodes gke-standard-cluster-2-default-pool-86353fdd-b7zb -o jsonpath='{.metadata.uid}{"\n"}'
e04fbdfa-ee7c-11e9-b924-42010a800201
$ kubectl exec -it netdata-slave-ltmfg cat /var/lib/netdata/registry/netdata.public.unique.id
e04fbdfa-ee7c-11e9-b924-42010a800201
```

Slave2:
```cmd
$ kubectl get nodes gke-standard-cluster-2-default-pool-86353fdd-494b -o jsonpath='{.metadata.uid}{"\n"}'
120c0e28-ee7c-11e9-b924-42010a800201
$ kubectl exec -it netdata-slave-rcrkj cat /var/lib/netdata/registry/netdata.public.unique.id
120c0e28-ee7c-11e9-b924-42010a800201
```

Slave3:
```cmd
$ kubectl get nodes gke-standard-cluster-2-default-pool-86353fdd-t45s -o jsonpath='{.metadata.uid}{"\n"}'
6dcd03ae-088e-11ea-82cc-42010a8001f7
$ kubectl exec -it netdata-slave-tqhdt cat /var/lib/netdata/registry/netdata.public.unique.id
6dcd03ae-088e-11ea-82cc-42010a8001f7
```