### PR TITLE
Bump NetData Helm Chart from v1.21.0 => v1.21.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # IntelliJ project files
 .idea
+*.bak
 *.iml
 out
 gen

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: netdata
 home: https://github.com/netdata/netdata
-version: 1.1.14
-appVersion: v1.21.0
+version: 1.1.15
+appVersion: v1.21.1
 description: Real-time performance monitoring, done right! https://my-netdata.io/
 maintainers:
   - name: Chris Akritidis

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Parameter | Description | Default
 --- | --- | ---
 `replicaCount` | Number of `replicas` for the master netdata `Statefulset` | `1`
 `image.repository` | Container image repo | `netdata/netdata`
-`image.tag` | Container image tag | Latest stable netdata release (e.g. `v1.21.0`)
+`image.tag` | Container image tag | Latest stable netdata release (e.g. `v1.21.1`)
 `image.pullPolicy` | Container image pull policy | `Always`
 `service.type` | netdata master service type | `ClusterIP`
 `service.port` | netdata master service port | `19999`

--- a/tools/update_helmchart.sh
+++ b/tools/update_helmchart.sh
@@ -110,7 +110,13 @@ _main() {
     new_version="$1"
   fi
 
-  new_appVersion="$(bump_version "$old_appVersion")"
+  # Bump patch version by default
+  if [ -z "$1" ]; then
+    new_appVersion="$(bump_version "$old_appVersion")"
+  else
+    # Or use supplied new version from first argument
+    new_appVersion="$1"
+  fi
 
   printf "\n"
   printf "New Chart version:    %s\n" "$new_version"

--- a/tools/update_helmchart.sh
+++ b/tools/update_helmchart.sh
@@ -1,0 +1,133 @@
+#!/bin/sh
+
+save_argv() {
+  for i; do
+    printf %s\\n "$i" | sed "s/'/'\\\\''/g;1s/^/'/;\$s/\$/' \\\\/"
+  done
+  echo " "
+}
+
+restore_argv() {
+  eval "set -- $*"
+}
+
+fnmatch() {
+  case "$2" in
+    $1)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+parse_version() {
+  r="${1}"
+  s="${2}"
+  if echo "${r}" | grep -q '^v.*'; then
+    # shellcheck disable=SC2001
+    # XXX: Need a regex group subsitutation here.
+    r="$(echo "${r}" | sed -e 's/^v\(.*\)/\1/')"
+  fi
+
+  old="$(save_argv)"
+  eval "set -- $(echo "${r}" | tr '-' ' ')"
+
+  v="$1"
+  b="$2"
+
+  if [ -z "$b" ] || fnmatch '*[!0-9]*' "$b"; then
+    b=
+  fi
+
+  eval "set -- $(echo "${v}" | tr '.' ' ')"
+  if [ -n "$b" ]; then
+    printf "%03d%s%03d%s%03d%s%03d" "$1" "$s" "$2" "$s" "$3" "$s" "$b"
+  else
+    printf "%03d%s%03d%s%03d" "$1" "$s" "$2" "$s" "$3"
+  fi
+  restore_argv "$old"
+}
+
+bump_version() {
+  v="$1"
+  n="$2"
+
+  old="$(save_argv)"
+  eval "set -- $(parse_version "$v" " ")"
+
+  major="${1#0*}"
+  minor="${2#0*}"
+  patch="${3#0*}"
+  build="${4#0*}"
+
+  restore_argv "$old"
+
+  case "$n" in
+    0)
+      major=$((major + 1))
+      minor=0
+      patch=0
+      [ -n "$build" ] && build=0
+      ;;
+    1)
+      minor=$((minor + 1))
+      patch=0
+      [ -n "$build" ] && build=0
+      ;;
+    2)
+      patch=$((patch + 1))
+      [ -n "$build" ] && build=0
+      ;;
+    3)
+      if [ -n "$build" ]; then
+        build=$((build + 1))
+      fi
+      ;;
+    *)
+      patch=$((patch + 1))
+      [ -n "$build" ] && build=0
+      ;;
+  esac
+
+  if [ -n "$build" ]; then
+    printf "%d.%d.%d-%d" "$major" "$minor" "$patch" "$build"
+  else
+    printf "%d.%d.%d" "$major" "$minor" "$patch"
+  fi
+}
+
+_main() {
+  old_version="$(grep -o -E '^version\:[[:space:]]+([0-9.]+)$' Chart.yaml | sed -E -e 's/^version\:[[:space:]]+([0-9.]+)$/\1/')"
+  old_appVersion="$(grep -o -E '^appVersion\:[[:space:]]+(v[0-9.]+)$' Chart.yaml | sed -E -e 's/^appVersion\:[[:space:]]+(v[0-9.]+)$/\1/')"
+  printf "Old Chart version:    %s\n" "$old_version"
+  printf "Old Chart appVersion: %s\n" "$old_appVersion"
+
+  if [ -z "$1" ]; then
+    new_version="$(bump_version "$old_version")"
+  else
+    new_version="$1"
+  fi
+
+  new_appVersion="$(bump_version "$old_appVersion")"
+
+  printf "\n"
+  printf "New Chart version:    %s\n" "$new_version"
+  printf "New Chart appVersion: v%s\n" "$new_appVersion"
+
+  git checkout -b "bump_$new_appVersion"
+
+  sed -i.bak \
+    -e "s/$old_version/$new_version/g" \
+    -e "s/$old_appVersion/v$new_appVersion/g" \
+    README.md Chart.yaml values.yaml
+
+  git add -A -p
+  git commit -m "Bump NetData Helm Chart from $old_appVersion => v$new_appVersion"
+  git push -u
+}
+
+if [ -n "$0" ] && [ x"$0" != x"-bash" ]; then
+  _main "$@"
+fi

--- a/values.yaml
+++ b/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: netdata/netdata
-  tag: v1.21.0
+  tag: v1.21.1
   pullPolicy: Always
 
 sysctlImage:


### PR DESCRIPTION
Also adds a tool to do this some-what automatically until we trust that the
tool does the right thing 100% of the time; then we'll integrate this into a
GHA workflow.

See `./tools/tools/update_helmchart.sh`. Usage is simple:

```#!sh
$ ./tools/tools/update_helmchart.sh
```

Which will bump the `patch` version by default.

Otherwise:

```#!sh
$ ./tools/tools/update_helmchart.sh v1.22.0
```

To update to a new version entirely.

The functions herein are 100% POSIX Sh compliant and the version parsing and
handling supports `x.y.z` as well as optional build `x.y.z-b` and bumping
any component with resetting others to zero as appropriate (_untested_).