### PR TITLE
Add priority class name

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: netdata
 home: https://github.com/netdata/netdata
-version: 1.1.14
+version: 1.2.0
 appVersion: v1.21.0
 description: Real-time performance monitoring, done right! https://my-netdata.io/
 maintainers:

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Parameter | Description | Default
 `master.nodeSelector` | Node selector for the master statefulset | `{}`
 `master.tolerations` | Tolerations settings for the master statefulset | `[]`
 `master.affinity` | Affinity settings for the master statefulset | `{}`
+`master.priorityClassName` | Pod priority class name for the master statefulset | `""`
 `master.database.persistence` | Whether the master should use a persistent volume for the DB | `true`
 `master.database.storageclass` | The storage class for the persistent volume claim of the master's database store, mounted to `/var/cache/netdata` | the default storage class
 `master.database.volumesize` | The storage space for the PVC of the master database | `2Gi`
@@ -90,6 +91,7 @@ Parameter | Description | Default
 `slave.nodeSelector` | Node selector for the slave daemonsets | `{}`
 `slave.tolerations` | Tolerations settings for the slave daemonsets | `- operator: Exists` with `effect: NoSchedule`
 `slave.affinity` | Affinity settings for the slave daemonsets | `{}`
+`slave.priorityClassName` | Pod priority class name for the slave daemonsets | `""`
 `slave.env` | Set environment parameters for the slave daemonset | `{}`
 `slave.podLabels` | Additional labels to add to the slave pods | `{}`
 `slave.podAnnotations` | Additional annotations to add to the slave pods | `{}`

--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -38,6 +38,9 @@ spec:
       hostPID: true
       hostIPC: true
       hostNetwork: true
+      {{- if .Values.slave.priorityClassName }}
+      priorityClassName: "{{ .Values.slave.priorityClassName }}"
+      {{- end }}
       initContainers:
       {{- if .Values.sysctlImage.enabled }}
         - name: init-sysctl

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -61,6 +61,9 @@ spec:
       securityContext:
         fsGroup: 201
       serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- if .Values.master.priorityClassName }}
+      priorityClassName: "{{ .Values.master.priorityClassName }}"
+      {{- end }}
       initContainers:
       {{- if .Values.sysctlImage.enabled }}
         - name: init-sysctl

--- a/values.yaml
+++ b/values.yaml
@@ -56,6 +56,8 @@ master:
 
   affinity: {}
 
+  priorityClassName: ""
+
   env: {}
     # To disable anonymous statistics:
     # DO_NOT_TRACK: 1
@@ -150,6 +152,8 @@ slave:
       effect: NoSchedule
 
   affinity: {}
+
+  priorityClassName: ""
 
   podLabels: {}
 


### PR DESCRIPTION
This is useful for infrastructure components and especially monitoring that needs to be there when things go wrong. Without a custom priority class, netdata agents can be killed under resource pressure just when you need them to be recording stats.

[Some](https://github.com/helm/charts/blob/6c7638eef1730a6e4de48f37fa3262a427106885/stable/prometheus/values.yaml#L48) other [charts](https://github.com/helm/charts/blob/6c7638eef1730a6e4de48f37fa3262a427106885/stable/datadog/values.yaml#L454) with this config.