### PR TITLE
Fix DNS errors

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: netdata
 home: https://github.com/netdata/netdata
-version: 1.2.0
+version: 1.2.1
 appVersion: v1.21.0
 description: Real-time performance monitoring, done right! https://my-netdata.io/
 maintainers:

--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -37,7 +37,6 @@ spec:
       restartPolicy: Always
       hostPID: true
       hostIPC: true
-      hostNetwork: true
       {{- if .Values.slave.priorityClassName }}
       priorityClassName: "{{ .Values.slave.priorityClassName }}"
       {{- end }}
@@ -183,5 +182,4 @@ spec:
         - name: nodeuid
           emptyDir: {}
         {{- end }}
-      dnsPolicy: ClusterFirstWithHostNet
 {{- end }}


### PR DESCRIPTION
Fixes #95 

Removed HostNetwork and ClusterFirstWithHostNetsettings, to let them go to default. 
Installed it in our test k8s cluster and didn't see any issues, but we'll need some more info on why this was done in the first place.