### PR TITLE
sd child configmap template: handle "string" value

### DIFF
--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -49,9 +49,13 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   {{ .Values.sd.child.configmap.key }}: |
-    {{- if .Values.sd.child.configmap.from.value }}
-      {{- toYaml .Values.sd.child.configmap.from.value | nindent 4 }}
-    {{- else }}
-      {{- .Files.Get .Values.sd.child.configmap.from.file | nindent 4 }}
+    {{- with .Values.sd.child.configmap.from }}
+      {{- if and (.value) (kindIs "string" .value) }}
+        {{- .value | nindent 4 }}
+      {{- else if .value }}
+        {{- toYaml .value | nindent 4 }}
+      {{- else }}
+        {{- $.Files.Get .file | nindent 4 }}
+      {{- end}}
     {{- end}}
-{{- end }}
+  {{- end }}

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -58,4 +58,4 @@ data:
         {{- $.Files.Get .file | nindent 4 }}
       {{- end}}
     {{- end}}
-  {{- end }}
+{{- end }}


### PR DESCRIPTION
ssia

it allows to use `--set-file` option

Tests:
- value not set
- value type is `string`
- value type is `map`
