### PR TITLE
child: add `updateStrategy` option

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: netdata
 home: https://github.com/netdata/netdata
-version: 2.0.1
+version: 2.0.2
 appVersion: v1.23.1
 description: Real-time performance monitoring, done right! https://my-netdata.io/
 maintainers:

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Parameter | Description | Default
 `parent.podAnnotations` | Additional annotations to add to the parent pods | `{}`
 `parent.configs` | Manage custom parent's configs | See [Configuration files](#configuration-files).
 `child.enabled` | Install child daemonset to gather data from nodes | `true`
+`child.updateStrategy` | An update strategy to replace existing DaemonSet pods with new pods | `{}`
 `child.resources` | Resources for the child daemonsets | `{}`
 `child.nodeSelector` | Node selector for the child daemonsets | `{}`
 `child.tolerations` | Tolerations settings for the child daemonsets | `- operator: Exists` with `effect: NoSchedule`

--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -10,6 +10,9 @@ metadata:
     heritage: {{ .Release.Service }}
     role: child
 spec:
+  {{- with .Values.child.updateStrategy }}
+  updateStrategy: {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       app: {{ template "netdata.name" . }}

--- a/values.yaml
+++ b/values.yaml
@@ -159,6 +159,11 @@ parent:
 child:
   enabled: true
 
+  updateStrategy: {}
+    # type: RollingUpdate
+    # rollingUpdate:
+    #   maxUnavailable: 1
+
   resources: {}
     # limits:
     #  cpu: 4


### PR DESCRIPTION
Fixes: #113

Tests:

- default, `updateStrategy` not set

```cmd
0 helmchart (ds_updateStrategy)$ helm template -s templates/daemonset.yaml . | yq -P r - spec.updateStrategy
0 helmchart (ds_updateStrategy)$
```

- `updateStrategy` set

```cmd
0 helmchart (ds_updateStrategy)$ helm template -s templates/daemonset.yaml --set child.updateStrategy.type=RollingUpdate,child.updateStrategy.rollingUpdate.maxUnavailable=1 . | yq -P r - spec.updateStrategy

rollingUpdate:
  maxUnavailable: 1
type: RollingUpdate
```