### PR TITLE
add parent agent claiming command for netdata cloud

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: netdata
 home: https://github.com/netdata/netdata
-version: 2.0.3
+version: 2.0.4
 appVersion: v1.23.2
 description: Real-time performance monitoring, done right! https://my-netdata.io/
 maintainers:

--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ Parameter | Description | Default
 `parent.podLabels` | Additional labels to add to the parent pods | `{}`
 `parent.podAnnotations` | Additional annotations to add to the parent pods | `{}`
 `parent.configs` | Manage custom parent's configs | See [Configuration files](#configuration-files).
+`parent.claiming.enabled` | Enable parent claiming for netdata cloud | `false`
+`parent.claiming.token` | Claim token | `""`
+`parent.claiming.room` | Separated list of claim rooms IDs | `""`
 `child.enabled` | Install child daemonset to gather data from nodes | `true`
 `child.updateStrategy` | An update strategy to replace existing DaemonSet pods with new pods | `{}`
 `child.resources` | Resources for the child daemonsets | `{}`

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Parameter | Description | Default
 `parent.configs` | Manage custom parent's configs | See [Configuration files](#configuration-files).
 `parent.claiming.enabled` | Enable parent claiming for netdata cloud | `false`
 `parent.claiming.token` | Claim token | `""`
-`parent.claiming.room` | Separated list of claim rooms IDs | `""`
+`parent.claiming.room` | Comma separated list of claim rooms IDs | `""`
 `child.enabled` | Install child daemonset to gather data from nodes | `true`
 `child.updateStrategy` | An update strategy to replace existing DaemonSet pods with new pods | `{}`
 `child.resources` | Resources for the child daemonsets | `{}`

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -81,6 +81,13 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if and .Values.parent.claiming.enabled .Values.parent.claiming.token .Values.parent.claiming.rooms }}
+          command:
+            - sh
+            - '-c'
+            - >
+              /usr/sbin/run.sh -W set2 cloud global enabled true -W set2 cloud global "cloud base url" "https://app.netdata.cloud" -W "claim -token={{ .Values.parent.claiming.token }} -rooms={{ .Values.parent.claiming.rooms }} -url={{ .Values.parent.claiming.url }}"
+          {{- end }}
           env:
             - name: MY_POD_NAME
               valueFrom:

--- a/values.yaml
+++ b/values.yaml
@@ -156,6 +156,12 @@ parent:
         info: random
           to: sysadmin
 
+  claiming:
+    enabled: false
+    token: ""
+    rooms: ""
+    url: "https://app.netdata.cloud"
+
 child:
   enabled: true
 


### PR DESCRIPTION
Fixes: https://github.com/netdata/helmchart/issues/79

**This PR**
* add parent agent claiming command for netdata cloud

**Related:**
* PR https://github.com/netdata/helmchart/pull/111
* Issue https://github.com/netdata/helmchart/issues/79

**Tests:**
- [x]  check templates generation, no errors (helm template .)
- [x] operational tests described in comments

**Test Environment:**
Kubernetes cluster v1.16.10 in AWS boostraped with Kops 1.16.3

Signed-off-by: Luis Garnica <lgarnica@geoblink.com>