### PR TITLE
sdconfig: add prometheus endpoints identification using `prometheus.io/scrape` annotation

### DIFF
--- a/sdconfig/child.yml
+++ b/sdconfig/child.yml
@@ -69,7 +69,7 @@ tag:
         expr: |
           {{ $scrapeOK := eq (get .Annotations "prometheus.io/scrape") "true" -}}
           {{ $portOK := eq (default .Port (get .Annotations "prometheus.io/port")) .Port -}}
-          {{ $imageOK := not (glob .Image "netdata/netdata*") -}}
+          {{ $imageOK := not (glob .Image "netdata/netdata*" "**pulsar*" "**telegraf*") -}}
           {{ and $scrapeOK $portOK $imageOK }}
 build:
   - name: "Control-Plane"

--- a/sdconfig/child.yml
+++ b/sdconfig/child.yml
@@ -29,6 +29,8 @@ tag:
         expr: '{{ and (eq .Port "8500") (glob .Image "consul*" "**/consul*") }}'
       - tags: coredns
         expr: '{{ and (eq .Port "9153") (glob .Image "**/coredns*") }}'
+      - tags: elasticsearch
+        expr: '{{ and (eq .Port "9200") (glob .Image "elasticsearch:*" "**/elasticsearch:*") }}'
       - tags: fluentd
         expr: '{{ and (eq .Port "24220") (glob .Image "fluentd*" "**/fluentd*") }}'
       - tags: freeradius
@@ -136,6 +138,11 @@ build:
           - module: coredns
             name: coredns-{{.TUID}}
             url: http://{{.Address}}/metrics
+      - selector: elasticsearch
+        template: |
+          - module: elasticsearch
+            name: elasticsearch-{{.TUID}}
+            url: http://{{.Address}}
       - selector: fluentd
         template: |
           - module: fluentd

--- a/sdconfig/child.yml
+++ b/sdconfig/child.yml
@@ -29,6 +29,8 @@ tag:
         expr: '{{ and (eq .Port "8500") (glob .Image "consul*" "**/consul*") }}'
       - tags: coredns
         expr: '{{ and (eq .Port "9153") (glob .Image "**/coredns*") }}'
+      - tags: elasticsearch
+        expr: '{{ and (eq .Port "9200") (glob .Image "elasticsearch:*" "*/elasticsearch:*") }}'
       - tags: fluentd
         expr: '{{ and (eq .Port "24220") (glob .Image "fluentd*" "**/fluentd*") }}'
       - tags: freeradius

--- a/sdconfig/child.yml
+++ b/sdconfig/child.yml
@@ -5,8 +5,17 @@ discovery:
       role: pod
       local_mode: true
 tag:
-  - selector: unknown
-    tags: -unknown go.d
+  - name: "Control-Plane"
+    selector: unknown
+    tags: -unknown control_plane
+    match:
+      - tags: kube_scheduler
+        expr: '{{ glob .Image "*/kube-scheduler*" }}'
+      - tags: kube_controller_manager
+        expr: '{{ glob .Image "k8s.gcr.io/kube-controller-manager:*" }}'
+  - name: "Applications"
+    selector: unknown
+    tags: -unknown applications
     match:
       - tags: activemq
         expr: '{{ and (eq .Port "8161") (glob .Image "**/activemq*") }}'
@@ -52,18 +61,50 @@ tag:
         expr: '{{ and (eq .Port "8888") (glob .Image "**/vernemq*") }}'
       - tags: zookeeper
         expr: '{{ and (eq .Port "2181") (glob .Image "zookeeper*" "**/zookeeper*") }}'
-  - selector: unknown
-    tags: -unknown go.d
+  - name: "Prometheus Generic Applications"
+    selector: unknown
+    tags: -unknown prometheus_generic
     match:
-      - tags: prometheus
+      - tags: prometheus_generic
         expr: |
           {{ $scrapeOK := eq (get .Annotations "prometheus.io/scrape") "true" -}}
           {{ $portOK := eq (default .Port (get .Annotations "prometheus.io/port")) .Port -}}
           {{ $imageOK := not (glob .Image "netdata/netdata*") -}}
           {{ and $scrapeOK $portOK $imageOK }}
 build:
-  - selector: "!unknown go.d"
-    tags: file go.d
+  - name: "Control-Plane"
+    selector: '!unknown control_plane'
+    tags: file
+    apply:
+      - selector: kube_scheduler
+        template: |
+          - module: prometheus
+            name: prometheus-{{.TUID}}
+            url: http://{{.PodIP}}:10251/metrics
+            update_every: 10
+            max_time_series: 1000
+      - selector: kube_controller_manager
+        template: |
+          - module: prometheus
+            name: prometheus-{{.TUID}}
+            url: http://{{.PodIP}}:10252/metrics
+            update_every: 10
+            max_time_series: 2000
+  - name: "Prometheus Generic Applications"
+    selector: '!unknown prometheus_generic'
+    tags: file
+    apply:
+      - selector: prometheus_generic
+        template: |
+          {{ $path := default "/metrics" (get .Annotations "prometheus.io/path") -}}
+          - module: prometheus
+            name: prometheus-{{.TUID}}
+            url: http://{{.Address}}{{$path}}
+            update_every: 10
+            max_time_series: 1000
+  - name: "Applications"
+    selector: '!unknown applications'
+    tags: file
     apply:
       - selector: activemq
         template: |
@@ -177,18 +218,7 @@ build:
           - module: zookeeper
             name: zookeeper-{{.TUID}}
             address: {{.Address}}
-  - selector: "!unknown prometheus"
-    tags: file go.d
-    apply:
-      - selector: prometheus
-        template: |
-          {{ $path := default "/metrics" (get .Annotations "prometheus.io/path") -}}
-          - module: prometheus
-            name: prometheus-{{.TUID}}
-            url: http://{{.Address}}{{$path}}
-            update_every: 10
-            max_time_series: 1000
 export:
   file:
-    - selector: file go.d
+    - selector: file
       filename: "/export/go.d.yml"

--- a/sdconfig/child.yml
+++ b/sdconfig/child.yml
@@ -52,6 +52,14 @@ tag:
         expr: '{{ and (eq .Port "8888") (glob .Image "**/vernemq*") }}'
       - tags: zookeeper
         expr: '{{ and (eq .Port "2181") (glob .Image "zookeeper*" "**/zookeeper*") }}'
+  - selector: unknown
+    tags: -unknown go.d
+    match:
+      - tags: prometheus
+        expr: |
+          {{ $isTarget := eq (get .Annotations "prometheus.io/scrape") "true" -}}
+          {{ $isBad := glob .Image "netdata/netdata*" -}}
+          {{ and $isTarget (not $isBad) }}
 build:
   - selector: "!unknown go.d"
     tags: file go.d
@@ -168,6 +176,17 @@ build:
           - module: zookeeper
             name: zookeeper-{{.TUID}}
             address: {{.Address}}
+  - selector: "!unknown prometheus"
+    tags: file go.d
+    apply:
+      - selector: prometheus
+        template: |
+          {{ $path := default "/metrics" (get .Annotations "prometheus.io/path") -}}
+          - module: prometheus
+            name: prometheus-{{.TUID}}
+            url: http://{{.Address}}{{$path}}
+            update_every: 10
+            max_time_series: 1000
 export:
   file:
     - selector: file go.d

--- a/sdconfig/child.yml
+++ b/sdconfig/child.yml
@@ -57,9 +57,10 @@ tag:
     match:
       - tags: prometheus
         expr: |
-          {{ $isTarget := eq (get .Annotations "prometheus.io/scrape") "true" -}}
-          {{ $isBad := glob .Image "netdata/netdata*" -}}
-          {{ and $isTarget (not $isBad) }}
+          {{ $scrapeOK := eq (get .Annotations "prometheus.io/scrape") "true" -}}
+          {{ $portOK := eq (default .Port (get .Annotations "prometheus.io/port")) .Port -}}
+          {{ $imageOK := not (glob .Image "netdata/netdata*") -}}
+          {{ and $scrapeOK $portOK $imageOK }}
 build:
   - selector: "!unknown go.d"
     tags: file go.d

--- a/sdconfig/child.yml
+++ b/sdconfig/child.yml
@@ -10,7 +10,7 @@ tag:
     tags: -unknown control_plane
     match:
       - tags: kube_scheduler
-        expr: '{{ glob .Image "*/kube-scheduler*" }}'
+        expr: '{{ glob .Image "k8s.gcr.io/kube-scheduler:*" }}'
       - tags: kube_controller_manager
         expr: '{{ glob .Image "k8s.gcr.io/kube-controller-manager:*" }}'
   - name: "Applications"
@@ -29,8 +29,6 @@ tag:
         expr: '{{ and (eq .Port "8500") (glob .Image "consul*" "**/consul*") }}'
       - tags: coredns
         expr: '{{ and (eq .Port "9153") (glob .Image "**/coredns*") }}'
-      - tags: elasticsearch
-        expr: '{{ and (eq .Port "9200") (glob .Image "elasticsearch:*" "*/elasticsearch:*") }}'
       - tags: fluentd
         expr: '{{ and (eq .Port "24220") (glob .Image "fluentd*" "**/fluentd*") }}'
       - tags: freeradius
@@ -82,14 +80,14 @@ build:
         template: |
           - module: prometheus
             name: prometheus-{{.TUID}}
-            url: http://{{.PodIP}}:10251/metrics
+            url: http://{{.PodIP}}:{{default "10251" .Port}}/metrics
             update_every: 10
             max_time_series: 1000
       - selector: kube_controller_manager
         template: |
           - module: prometheus
             name: prometheus-{{.TUID}}
-            url: http://{{.PodIP}}:10252/metrics
+            url: http://{{.PodIP}}:{{default "10252" .Port}}/metrics
             update_every: 10
             max_time_series: 2000
   - name: "Prometheus Generic Applications"

--- a/values.yaml
+++ b/values.yaml
@@ -9,7 +9,7 @@ image:
 
 sd:
   repository: netdata/agent-sd
-  tag: v0.1.0
+  tag: v0.2.0
   pullPolicy: Always
   child:
     enabled: true

--- a/values.yaml
+++ b/values.yaml
@@ -9,7 +9,7 @@ image:
 
 sd:
   repository: netdata/agent-sd
-  tag: v0.2.0
+  tag: v0.2.1
   pullPolicy: Always
   child:
     enabled: true

--- a/values.yaml
+++ b/values.yaml
@@ -19,8 +19,8 @@ sd:
       # if 'from' is {} the ConfigMap is not generated
       from:
         file: sdconfig/child.yml
-        value: { }
-    resources: { }
+        value: {}
+    resources: {}
     # limits:
     #  cpu: 50m
     #  memory: 60Mi
@@ -33,8 +33,8 @@ sysctlImage:
   repository: alpine
   tag: latest
   pullPolicy: Always
-  command: [ ]
-  resources: { }
+  command: []
+  resources: {}
 
 service:
   type: ClusterIP
@@ -65,7 +65,7 @@ serviceAccount:
 
 
 parent:
-  resources: { }
+  resources: {}
     # limits:
     #  cpu: 4
     #  memory: 4096Mi
@@ -73,21 +73,21 @@ parent:
     #  cpu: 4
   #  memory: 4096Mi
 
-  nodeSelector: { }
+  nodeSelector: {}
 
-  tolerations: [ ]
+  tolerations: []
 
-  affinity: { }
+  affinity: {}
 
   priorityClassName: ""
 
-  env: { }
+  env: {}
     # To disable anonymous statistics:
   # DO_NOT_TRACK: 1
 
-  podLabels: { }
+  podLabels: {}
 
-  podAnnotations: { }
+  podAnnotations: {}
 
   database:
     persistence: true
@@ -167,12 +167,12 @@ parent:
 child:
   enabled: true
 
-  updateStrategy: { }
+  updateStrategy: {}
     # type: RollingUpdate
     # rollingUpdate:
   #   maxUnavailable: 1
 
-  resources: { }
+  resources: {}
     # limits:
     #  cpu: 4
     #  memory: 4096Mi
@@ -180,22 +180,22 @@ child:
     #  cpu: 4
   #  memory: 4096Mi
 
-  nodeSelector: { }
+  nodeSelector: {}
 
   tolerations:
     - operator: Exists
       effect: NoSchedule
 
-  affinity: { }
+  affinity: {}
 
   priorityClassName: ""
 
-  podLabels: { }
+  podLabels: {}
 
   podAnnotationAppArmor:
     enabled: true
 
-  podAnnotations: { }
+  podAnnotations: {}
 
   persistUniqueID: true
 
@@ -246,6 +246,6 @@ child:
         jobs:
           - url: http://127.0.0.1:10249/metrics
 
-  env: { }
+  env: {}
     # To disable anonymous statistics:
-  # DO_NOT_TRACK: 1
+    # DO_NOT_TRACK: 1

--- a/values.yaml
+++ b/values.yaml
@@ -19,8 +19,8 @@ sd:
       # if 'from' is {} the ConfigMap is not generated
       from:
         file: sdconfig/child.yml
-        value: {}
-    resources: {}
+        value: { }
+    resources: { }
     # limits:
     #  cpu: 50m
     #  memory: 60Mi
@@ -33,8 +33,8 @@ sysctlImage:
   repository: alpine
   tag: latest
   pullPolicy: Always
-  command: []
-  resources: {}
+  command: [ ]
+  resources: { }
 
 service:
   type: ClusterIP
@@ -65,29 +65,29 @@ serviceAccount:
 
 
 parent:
-  resources: {}
+  resources: { }
     # limits:
     #  cpu: 4
     #  memory: 4096Mi
     # requests:
     #  cpu: 4
-    #  memory: 4096Mi
+  #  memory: 4096Mi
 
-  nodeSelector: {}
+  nodeSelector: { }
 
-  tolerations: []
+  tolerations: [ ]
 
-  affinity: {}
+  affinity: { }
 
   priorityClassName: ""
 
-  env: {}
+  env: { }
     # To disable anonymous statistics:
-    # DO_NOT_TRACK: 1
+  # DO_NOT_TRACK: 1
 
-  podLabels: {}
+  podLabels: { }
 
-  podAnnotations: {}
+  podAnnotations: { }
 
   database:
     persistence: true
@@ -167,35 +167,35 @@ parent:
 child:
   enabled: true
 
-  updateStrategy: {}
+  updateStrategy: { }
     # type: RollingUpdate
     # rollingUpdate:
-    #   maxUnavailable: 1
+  #   maxUnavailable: 1
 
-  resources: {}
+  resources: { }
     # limits:
     #  cpu: 4
     #  memory: 4096Mi
     # requests:
     #  cpu: 4
-    #  memory: 4096Mi
+  #  memory: 4096Mi
 
-  nodeSelector: {}
+  nodeSelector: { }
 
   tolerations:
     - operator: Exists
       effect: NoSchedule
 
-  affinity: {}
+  affinity: { }
 
   priorityClassName: ""
 
-  podLabels: {}
+  podLabels: { }
 
   podAnnotationAppArmor:
     enabled: true
 
-  podAnnotations: {}
+  podAnnotations: { }
 
   persistUniqueID: true
 
@@ -225,15 +225,8 @@ child:
       path: /etc/netdata/go.d.conf
       data: |
         modules:
-          apache: yes
-          bind: yes
-          freeradius: yes
-          lighttpd: yes
-          mysql: yes
-          nginx: yes
-          openvpn: yes
-          phpfpm: yes
-          rabbitmq: yes
+          pulsar: no
+          prometheus: yes
     kubelet:
       enabled: true
       path: /etc/netdata/go.d/k8s_kubelet.conf
@@ -253,6 +246,6 @@ child:
         jobs:
           - url: http://127.0.0.1:10249/metrics
 
-  env: {}
+  env: { }
     # To disable anonymous statistics:
-    # DO_NOT_TRACK: 1
+  # DO_NOT_TRACK: 1

--- a/values.yaml
+++ b/values.yaml
@@ -71,7 +71,7 @@ parent:
     #  memory: 4096Mi
     # requests:
     #  cpu: 4
-  #  memory: 4096Mi
+    #  memory: 4096Mi
 
   nodeSelector: {}
 
@@ -83,7 +83,7 @@ parent:
 
   env: {}
     # To disable anonymous statistics:
-  # DO_NOT_TRACK: 1
+    # DO_NOT_TRACK: 1
 
   podLabels: {}
 
@@ -170,7 +170,7 @@ child:
   updateStrategy: {}
     # type: RollingUpdate
     # rollingUpdate:
-  #   maxUnavailable: 1
+    #   maxUnavailable: 1
 
   resources: {}
     # limits:
@@ -178,7 +178,7 @@ child:
     #  memory: 4096Mi
     # requests:
     #  cpu: 4
-  #  memory: 4096Mi
+    #  memory: 4096Mi
 
   nodeSelector: {}
 


### PR DESCRIPTION
blocked by:
- [x] netdata v1.25.0 release
- [x] sd new version release

Blockers are resloved.

---

Fixes: netdata/netdata#9774

This PR changes service discovery config, it adds identification prometheus enpoints via well-known annotations:

- `prometheus.io/scrape`: The default configuration will scrape all pods and, if set to false, this annotation will exclude the pod from the scraping process.
- `prometheus.io/path`: If the metrics path is not /metrics, define it with this annotation.
- `prometheus.io/port`: Scrape the pod on the indicated port instead of the pod’s declared ports (default is a port-free target if none are declared).

I tested this PR locally in minikube and on gke.