### PR TITLE
Add ability to control graceful shutdown period

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Parameter | Description | Default
 `clusterrole.name` | Name of the cluster role linked with the service account | `netdata`
 `APIKEY` | The key shared between the parent and the child netdata for streaming | `11111111-2222-3333-4444-555555555555`
 `parent.resources` | Resources for the parent deployment | `{}`
+`parent.terminationGracePeriodSeconds` | Duration in seconds the pod needs to terminate gracefully | `300`
 `parent.nodeSelector` | Node selector for the parent deployment | `{}`
 `parent.tolerations` | Tolerations settings for the parent deployment | `[]`
 `parent.affinity` | Affinity settings for the parent deployment | `{}`
@@ -105,6 +106,7 @@ Parameter | Description | Default
 `child.enabled` | Install child daemonset to gather data from nodes | `true`
 `child.updateStrategy` | An update strategy to replace existing DaemonSet pods with new pods | `{}`
 `child.resources` | Resources for the child daemonsets | `{}`
+`child.terminationGracePeriodSeconds` | Duration in seconds the pod needs to terminate gracefully | `30`
 `child.nodeSelector` | Node selector for the child daemonsets | `{}`
 `child.tolerations` | Tolerations settings for the child daemonsets | `- operator: Exists` with `effect: NoSchedule`
 `child.affinity` | Affinity settings for the child daemonsets | `{}`

--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -111,10 +111,6 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh","-c","killall netdata; while killall -0 netdata; do sleep 1; done"]
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}
@@ -198,6 +194,7 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.child.terminationGracePeriodSeconds }}
       volumes:
         - name: proc
           hostPath:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -74,10 +74,6 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh","-c","killall netdata; while killall -0 netdata; do sleep 1; done"]
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}
@@ -128,6 +124,7 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.parent.terminationGracePeriodSeconds }}
       volumes:
         - name: config
           configMap:

--- a/values.yaml
+++ b/values.yaml
@@ -73,6 +73,8 @@ parent:
     #  cpu: 4
     #  memory: 4096Mi
 
+  terminationGracePeriodSeconds: 300
+
   nodeSelector: {}
 
   tolerations: []
@@ -179,6 +181,8 @@ child:
     # requests:
     #  cpu: 4
     #  memory: 4096Mi
+
+  terminationGracePeriodSeconds: 30
 
   nodeSelector: {}
 


### PR DESCRIPTION
The default shutdown time (30 seconds) is not enough for parent node in our case. Time-to-time we get a corrupted database during node maintenance/lifecycle (we are using preemptible nodes on dev environment). So we would like to control shutdown time.

BTW, lifecycle.preStop does not help in this case. Bcz if the preStop hook hangs during execution, the Pod phase stays in a Terminating state and is killed after terminationGracePeriodSeconds of pod ends [(doc)](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#hook-handler-execution).

I would like to suggest to increase the default value of `parent.terminationGracePeriodSeconds` up to 300 seconds by default. Such value will be more friendly for users with slow IO or big databases.