### PR TITLE
Fix changing netdata's listen port

### DIFF
--- a/charts/netdata/templates/daemonset.yaml
+++ b/charts/netdata/templates/daemonset.yaml
@@ -103,6 +103,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: NETDATA_LISTENER_PORT
+              value: '{{ .Values.service.port }}'
             {{- if .Values.sd.child.enabled }}
             - name: NETDATA_PLUGINS_GOD_WATCH_PATH
               value: "/etc/netdata/go.d/sd/go.d.yml"

--- a/charts/netdata/templates/deployment.yaml
+++ b/charts/netdata/templates/deployment.yaml
@@ -70,6 +70,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: NETDATA_LISTENER_PORT
+              value: '{{ .Values.service.port }}'
             {{- range $key, $value := .Values.parent.env }}
             - name: {{ $key }}
               value: {{ $value | quote }}

--- a/charts/netdata/values.yaml
+++ b/charts/netdata/values.yaml
@@ -131,7 +131,7 @@ parent:
       data: |
         [global]
           memory mode = save
-          bind to = 0.0.0.0:19999
+
         [plugins]
           cgroups = no
           tc = no


### PR DESCRIPTION
This requires v1.26 or newer of the agent's docker image in order to work.