### PR TITLE
charts/netdata/Chart.yaml: Upgrade to Helm v3

### DIFF
--- a/charts/netdata/Chart.yaml
+++ b/charts/netdata/Chart.yaml
@@ -1,7 +1,8 @@
-apiVersion: v1
+apiVersion: v2
 name: netdata
-version: 2.0.15
+version: 3.0.0
 description: Real-time performance monitoring, done right!
+type: application
 keywords:
   - alerting
   - metric


### PR DESCRIPTION
To be merged after Helm v2 EOL (Nov 13th 2020)
https://helm.sh/blog/helm-v2-deprecation-timeline/