### PR TITLE
sdconfig: handle `"prometheus.io/port"` is port `name` case

### DIFF
--- a/charts/netdata/sdconfig/child.yml
+++ b/charts/netdata/sdconfig/child.yml
@@ -70,8 +70,7 @@ tag:
       - tags: prometheus_generic
         expr: |
           {{ $scrapeOK := eq (get .Annotations "prometheus.io/scrape") "true" -}}
-          {{ $port := default .Port (get .Annotations "prometheus.io/port") }}
-          {{ $portOK := or (eq $port .Port) (eq $port .PortName) -}}
+          {{ $portOK := eq (default .Port (get .Annotations "prometheus.io/port")) .Port .PortName -}}
           {{ $imageOK := not (glob .Image "netdata/netdata*" "**pulsar*" "**telegraf*") -}}
           {{ and $scrapeOK $portOK $imageOK }}
 build:

--- a/charts/netdata/sdconfig/child.yml
+++ b/charts/netdata/sdconfig/child.yml
@@ -70,7 +70,8 @@ tag:
       - tags: prometheus_generic
         expr: |
           {{ $scrapeOK := eq (get .Annotations "prometheus.io/scrape") "true" -}}
-          {{ $portOK := eq (default .Port (get .Annotations "prometheus.io/port")) .Port -}}
+          {{ $port := default .Port (get .Annotations "prometheus.io/port") }}
+          {{ $portOK := or (eq $port .Port) (eq $port .PortName) -}}
           {{ $imageOK := not (glob .Image "netdata/netdata*" "**pulsar*" "**telegraf*") -}}
           {{ and $scrapeOK $portOK $imageOK }}
 build:


### PR DESCRIPTION
```cmd
0 sd (master *%)$ kubectl get pods -A -o yaml | grep "prometheus.io/port"
      prometheus.io/port: "9402"
      prometheus.io/port: "9000"
      prometheus.io/port: "9000"
      prometheus.io/port: "8080"
      prometheus.io/port: "8080"
      prometheus.io/port: "8080"
      prometheus.io/port: "9121"
      prometheus.io/port: "9121"
      prometheus.io/port: "9121"
      prometheus.io/port: "9121"
      prometheus.io/port: "9000"
      prometheus.io/port: "8888"
      prometheus.io/port: http-metrics
      prometheus.io/port: "19999"
      prometheus.io/port: "19999"
      prometheus.io/port: "19999"
      prometheus.io/port: "19999"
      prometheus.io/port: http-metrics
      prometheus.io/port: http-metrics
      prometheus.io/port: http-metrics
      prometheus.io/port: "9216"
      prometheus.io/port: "9216"
      prometheus.io/port: "9216"
      prometheus.io/port: "8000"
      prometheus.io/port: "8000"
      prometheus.io/port: "8080"
      prometheus.io/port: "8080"
      prometheus.io/port: "8000"
      prometheus.io/port: "8000"
      prometheus.io/port: "8000"
```