### PR TITLE
nd child init nodeuid container: set minimal cpu requests

### DIFF
--- a/charts/netdata/Chart.yaml
+++ b/charts/netdata/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netdata
-version: 3.0.1
+version: 3.1.0
 description: Real-time performance monitoring, done right!
 type: application
 keywords:

--- a/charts/netdata/README.md
+++ b/charts/netdata/README.md
@@ -1,6 +1,6 @@
 # Netdata Helm chart for Kubernetes deployments
 
-[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/netdata)](https://artifacthub.io/packages/search?repo=netdata) ![Version: 3.0.1](https://img.shields.io/badge/Version-3.0.1-informational) ![AppVersion: v1.26.0](https://img.shields.io/badge/AppVersion-v1.26.0-informational)
+[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/netdata)](https://artifacthub.io/packages/search?repo=netdata) ![Version: 3.1.0](https://img.shields.io/badge/Version-3.1.0-informational) ![AppVersion: v1.26.0](https://img.shields.io/badge/AppVersion-v1.26.0-informational)
 
 _Based on the work of varyumin (https://github.com/varyumin/netdata)_.
 

--- a/charts/netdata/templates/daemonset.yaml
+++ b/charts/netdata/templates/daemonset.yaml
@@ -61,6 +61,9 @@ spec:
         {{- if .Values.child.persistUniqueID }}
         - name: init-nodeuid
           image: "{{ .Values.wgetImage.repository }}:{{ .Values.wgetImage.tag }}"
+          resources:
+            requests:
+              cpu: 1m
           imagePullPolicy: {{ .Values.wgetImage.pullPolicy }}
           volumeMounts:
             - name: nodeuid

--- a/charts/netdata/templates/daemonset.yaml
+++ b/charts/netdata/templates/daemonset.yaml
@@ -63,7 +63,7 @@ spec:
           image: "{{ .Values.wgetImage.repository }}:{{ .Values.wgetImage.tag }}"
           resources:
             requests:
-              cpu: 1m
+              cpu: 10m
           imagePullPolicy: {{ .Values.wgetImage.pullPolicy }}
           volumeMounts:
             - name: nodeuid


### PR DESCRIPTION
There is webhook on GKE - it sets `resources->requests->cpu: 100m` if the parameter is empty.

I think it is ok to have minimal and hardcoded cpu req for `init-nodeuid` init container.

---

Every time i install nd via helmchart on my potato cluster i have to tune this parameter b/c one node has no 100m of cpu 😄 