### PR TITLE
allow netdata to get/list namespaces

### DIFF
--- a/charts/netdata/Chart.yaml
+++ b/charts/netdata/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netdata
-version: 3.1.0
+version: 3.2.0
 description: Real-time performance monitoring, done right!
 type: application
 keywords:

--- a/charts/netdata/README.md
+++ b/charts/netdata/README.md
@@ -1,6 +1,6 @@
 # Netdata Helm chart for Kubernetes deployments
 
-[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/netdata)](https://artifacthub.io/packages/search?repo=netdata) ![Version: 3.1.0](https://img.shields.io/badge/Version-3.1.0-informational) ![AppVersion: v1.26.0](https://img.shields.io/badge/AppVersion-v1.26.0-informational)
+[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/netdata)](https://artifacthub.io/packages/search?repo=netdata) ![Version: 3.2.0](https://img.shields.io/badge/Version-3.2.0-informational) ![AppVersion: v1.26.0](https://img.shields.io/badge/AppVersion-v1.26.0-informational)
 
 _Based on the work of varyumin (https://github.com/varyumin/netdata)_.
 

--- a/charts/netdata/templates/clusterrole.yaml
+++ b/charts/netdata/templates/clusterrole.yaml
@@ -26,6 +26,7 @@ rules:
       - "watch"
   - apiGroups: [""]
     resources:
+      - "namespaces"
       - "resourcequotas"
     verbs:
       - "get"


### PR DESCRIPTION
This is needed to get `kube-system` namespace uid, plan to use it as cluster_id.