### PR TITLE
Restructure agent PR generation to produce verified commits.

### DIFF
--- a/.github/workflows/agent-pr.yml
+++ b/.github/workflows/agent-pr.yml
@@ -22,16 +22,25 @@ jobs:
           git config --global user.name Netdatabot
           git config --global user.email bot@netdata.cloud
       - name: Create Branch
-        run: git checkout -b agent-${{ github.event.inputs.agent_version }}
+        run: |
+          git checkout -b agent-${{ github.event.inputs.agent_version }}
+          git push -u origin agent-${{ github.event.inputs.agent_version }}
       - name: Update Files
         run: .github/scripts/update-agent-version.py ${{ github.event.inputs.agent_version }}
       - name: Commit Changes
-        run: git commit -a -m 'Update agent version to ${{ github.event.inputs.agent_version }}.'
-      - name: Push Branch
-        run: git push -u origin agent-${{ github.event.inputs.agent_version }}
+        uses: swinton/commit@v2.x
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          files: |
+            charts/netdata/Chart.yaml
+            charts/netdata/README.md
+          commit-message: 'Update agent version to ${{ github.event.inputs.agent_version }}.'
+          ref: refs/heads/agent-${{ github.event.inputs.agent_version }}
       - name: Create PR
         uses: repo-sync/pull-request@v2
         with:
           source_branch: agent-${{ github.event.inputs.agent_version }}
           pr_title: 'Update agent version to ${{ github.event.inputs.agent_version }}.'
+          pr_body: 'See https://github.com/netdata/netdata/releases/tag/${{ github.event.inputs.agent_version }} for release notes.'
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/agent-pr.yml
+++ b/.github/workflows/agent-pr.yml
@@ -41,6 +41,6 @@ jobs:
         uses: repo-sync/pull-request@v2
         with:
           source_branch: agent-${{ github.event.inputs.agent_version }}
-          pr_title: 'Update agent version to ${{ github.event.inputs.agent_version }}.'
+          pr_title: 'Update agent version to ${{ github.event.inputs.agent_version }}'
           pr_body: 'See https://github.com/netdata/netdata/releases/tag/${{ github.event.inputs.agent_version }} for release notes.'
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This restructures the GHA workflow responsible for generating agent version update PRs so that it produces verified commits by using the GitHub API to generate the commit instead of generating it locally on the runner and then pushing to GitHub. Making sure these commits are verified is important to helping foster user trust.

The resultant workflow is technically more verbose, but actually has one less step than the original approach did.