### PR TITLE
fixbug deprecated ingress type

### DIFF
--- a/charts/netdata/templates/ingress.yaml
+++ b/charts/netdata/templates/ingress.yaml
@@ -2,7 +2,11 @@
 {{- $fullName := include "netdata.name" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
 
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
 apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}


### PR DESCRIPTION
otherwise, linting the chart will show:

```
 [ERROR] templates/ingress.yaml: the kind "extensions/v1beta1 Ingress" is deprecated in favor of "networking.k8s.io/v1beta1 Ingress"
```