### PR TITLE
Fix unknown field "serviceName" in io.k8s.api.networking.v1.IngressBackend for Kubernetes 1.19+

### DIFF
--- a/charts/netdata/templates/ingress.yaml
+++ b/charts/netdata/templates/ingress.yaml
@@ -26,8 +26,11 @@ spec:
       http:
         paths:
           - path: {{ $ingressPath }}
+            pathType: Prefix
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+              service:
+                name: {{$fullName}}
+                port:
+                  name: http
   {{- end }}
 {{- end }}


### PR DESCRIPTION
`networking.k8s.io/v1alpha1` is deprecated for Kubernetes 1.21, causing `Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: [ValidationError(Ingress.spec.rules[0].http.paths[0].backend): unknown field "serviceName" in io.k8s.api.networking.v1.IngressBackend, ValidationError(Ingress.spec.rules[0].http.paths[0].backend): unknown field "servicePort" in io.k8s.api.networking.v1.IngressBackend]`. This PR updates the API definition to `networking.k8s.io/v1`