### PR TITLE
Fix Ingress for K8s >= 1.19

### DIFF
--- a/charts/netdata/Chart.yaml
+++ b/charts/netdata/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netdata
-version: 3.6.9
+version: 3.6.10
 description: Real-time performance monitoring, done right!
 type: application
 keywords:

--- a/charts/netdata/templates/ingress.yaml
+++ b/charts/netdata/templates/ingress.yaml
@@ -1,8 +1,9 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "netdata.name" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
+{{- $apiVersion := (include "netdata.ingress.apiVersion" .) -}}
 
-apiVersion: {{ include "netdata.ingress.apiVersion" . }}
+apiVersion: {{ $apiVersion }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -26,8 +27,18 @@ spec:
       http:
         paths:
           - path: {{ $ingressPath }}
+            {{- if and (ne $apiVersion "extensions/v1beta1") (ne $apiVersion "networking.k8s.io/v1beta1") }}
+            pathType: Prefix
+            {{- end }}
             backend:
+              {{- if or (eq $apiVersion "extensions/v1beta1") (eq $apiVersion "networking.k8s.io/v1beta1") }}
               serviceName: {{ $fullName }}
               servicePort: http
+              {{- else }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
+              {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/netdata/templates/ingress.yaml
+++ b/charts/netdata/templates/ingress.yaml
@@ -27,11 +27,11 @@ spec:
       http:
         paths:
           - path: {{ $ingressPath }}
-            {{- if and (ne $apiVersion "extensions/v1beta1") (ne $apiVersion "networking.k8s.io/v1beta1") }}
+            {{- if not (eq $apiVersion "extensions/v1beta1" "networking.k8s.io/v1beta1") }}
             pathType: Prefix
             {{- end }}
             backend:
-              {{- if or (eq $apiVersion "extensions/v1beta1") (eq $apiVersion "networking.k8s.io/v1beta1") }}
+              {{- if eq $apiVersion "extensions/v1beta1" "networking.k8s.io/v1beta1" }}
               serviceName: {{ $fullName }}
               servicePort: http
               {{- else }}


### PR DESCRIPTION
I'm really sorry that my #205 was not completed and I forgot to patch the Ingress object.

This PR should fix compatibility with K8S >= 1.19 and replaces #210

This is correct that K8S 1.19 still supports networking.k8s.io/v1beta1 but then very soon kubectl will report deprecations and it is better idea to detect used version and change slightly the resource based on desired version.

In Google Cloud now 1.19 is a main version since this week and then more and more people will need this bug fixed.
