### PR TITLE
use environment variables for claiming

### DIFF
--- a/charts/netdata/Chart.yaml
+++ b/charts/netdata/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netdata
-version: 3.6.11
+version: 3.6.13
 description: Real-time performance monitoring, done right!
 type: application
 keywords:

--- a/charts/netdata/Chart.yaml
+++ b/charts/netdata/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netdata
-version: 3.6.12
+version: 3.6.13
 description: Real-time performance monitoring, done right!
 type: application
 keywords:

--- a/charts/netdata/README.md
+++ b/charts/netdata/README.md
@@ -1,6 +1,6 @@
 # Netdata Helm chart for Kubernetes deployments
 
-[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/netdata)](https://artifacthub.io/packages/search?repo=netdata) ![Version: 3.6.12](https://img.shields.io/badge/Version-3.6.12-informational) ![AppVersion: v1.31.0](https://img.shields.io/badge/AppVersion-v1.31.0-informational)
+[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/netdata)](https://artifacthub.io/packages/search?repo=netdata) ![Version: 3.6.13](https://img.shields.io/badge/Version-3.6.13-informational) ![AppVersion: v1.31.0](https://img.shields.io/badge/AppVersion-v1.31.0-informational)
 
 _Based on the work of varyumin (https://github.com/varyumin/netdata)_.
 

--- a/charts/netdata/README.md
+++ b/charts/netdata/README.md
@@ -1,6 +1,6 @@
 # Netdata Helm chart for Kubernetes deployments
 
-[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/netdata)](https://artifacthub.io/packages/search?repo=netdata) ![Version: 3.6.11](https://img.shields.io/badge/Version-3.6.11-informational) ![AppVersion: v1.31.0](https://img.shields.io/badge/AppVersion-v1.31.0-informational)
+[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/netdata)](https://artifacthub.io/packages/search?repo=netdata) ![Version: 3.6.13](https://img.shields.io/badge/Version-3.6.13-informational) ![AppVersion: v1.31.0](https://img.shields.io/badge/AppVersion-v1.31.0-informational)
 
 _Based on the work of varyumin (https://github.com/varyumin/netdata)_.
 

--- a/charts/netdata/templates/daemonset.yaml
+++ b/charts/netdata/templates/daemonset.yaml
@@ -80,18 +80,15 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ tpl .Values.image.tag . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- with .Values.child.claiming }}
-          {{- if and .enabled .token .rooms }}
-          command:
-            - "/bin/sh"
-            - "-c"
-            - exec /usr/sbin/run.sh
-              -W set2 cloud global enabled true
-              -W set2 cloud global "cloud base url" "{{ .url }}"
-              -W "claim -token={{ .token }} -rooms={{ .rooms }} -url={{ .url }}"
-          {{- end }}
-          {{- end }}
           env:
+            {{- if .Values.child.claiming.enabled }}
+            - name: NETDATA_CLAIM_URL
+              value: "{{ .Values.child.claiming.url }}"
+            - name: NETDATA_CLAIM_TOKEN
+              value: "{{ .Values.child.claiming.token }}"
+            - name: NETDATA_CLAIM_ROOMS
+              value: "{{ .Values.child.claiming.rooms }}"
+            {{- end }}
             - name: MY_POD_NAME
               valueFrom:
                 fieldRef:

--- a/charts/netdata/templates/deployment.yaml
+++ b/charts/netdata/templates/deployment.yaml
@@ -55,18 +55,15 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ tpl .Values.image.tag . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- with .Values.parent.claiming }}
-          {{- if and .enabled .token .rooms }}
-          command:
-            - "/bin/sh"
-            - "-c"
-            - exec /usr/sbin/run.sh
-              -W set2 cloud global enabled true
-              -W set2 cloud global "cloud base url" "{{ .url }}"
-              -W "claim -token={{ .token }} -rooms={{ .rooms }} -url={{ .url }}"
-          {{- end }}
-          {{- end }}
           env:
+            {{- if .Values.parent.claiming.enabled }}
+            - name: NETDATA_CLAIM_URL
+              value: "{{ .Values.parent.claiming.url }}"
+            - name: NETDATA_CLAIM_TOKEN
+              value: "{{ .Values.parent.claiming.token }}"
+            - name: NETDATA_CLAIM_ROOMS
+              value: "{{ .Values.parent.claiming.rooms }}"
+            {{- end }}
             - name: MY_POD_NAME
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
This PR changes claiming logic from using [command line](https://learn.netdata.cloud/docs/agent/claim#netdata-agent-command-line) to [environment variables](https://learn.netdata.cloud/docs/agent/claim#using-environment-variables).

The latter is better because we [don't try to claim on every container start if it is already claimed](https://github.com/netdata/netdata/blob/e4f0ae2290a36bb1b9184fffac1e9ed1f707c52e/packaging/docker/run.sh#L23-L28).

---

⚠️ Claiming using environment variables works since v1.30.0 ([there was a bug in prev versions](https://github.com/netdata/netdata/pull/10811)). Do we need to keep support for old versions? (fallback to _command line_ claiming if version < 1.30.0 ).

@Ferroin @knatsakis ?

**This PR doesn't keep compatibility: Netdata version < 1.30.0 + claiming doesn't work.**

---

Tests:

- install on GKE, ensure parent/children are claimed and connected to the Cloud.


---

~@Ferroin There is [_a bug_ in the netdata-claim.sh](https://github.com/netdata/netdata/blob/master/claim/netdata-claim.sh.in#L403-L422):~
 - ~we execute the script before starting the Agent~
 - ~it always `exit 5` the first time because the script expects the Agent to be running~

Fixed in https://github.com/netdata/netdata/pull/11195