### PR TITLE
adds support for ingress v1 final api

### DIFF
--- a/charts/netdata/templates/ingress.yaml
+++ b/charts/netdata/templates/ingress.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.ingress.enabled -}}
+{{- $isv1api := semverCompare ">=1.19-0" .Capabilities.KubeVersion.Version -}}
 {{- $fullName := include "netdata.name" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
 
@@ -27,7 +28,15 @@ spec:
         paths:
           - path: {{ $ingressPath }}
             backend:
+            {{- if $isv1api }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
+            pathType: Prefix
+            {{ else }}
               serviceName: {{ $fullName }}
               servicePort: http
+            {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
When trying to install netdata on a 1.20.2 cluster hosted on DigitalOcean DOKS, I encountered issues with the new v1 ingress API... Here's a fix to the helm chart to account for the new backend syntax.

I've only tested the fix on 1.20.2 but >=1.19.0 should work (and require the change).