### PR TITLE
Adding checks Workflow

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,43 @@
+---
+name: Lint and Test Charts
+
+on: pull_request
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.4.0
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.1.0
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed)
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
+
+      - name: Run chart-testing (lint)
+        run: ct lint --check-version-increment=false --validate-maintainers=false
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.2.0
+        if: steps.list-changed.outputs.changed == 'true'
+
+      - name: Run chart-testing (install)
+        run: ct install


### PR DESCRIPTION
**Issue:** #81 
**Scope:**  Adding new workflow to check Helm charts in Pull Requests.

**Description:**

- Version bumping done via `Agent Version PR` Workflow, Which i could not test. I think we could enable version increment  checks here once you approve this. For now i kept it disable.

-  Helm insists that Chart Maintainers Names will be the VCS usernames,  I've tested it  the tests will pass if i will rename all maintainers names, as described [here](https://github.com/helm/chart-testing/issues/192). Can be enabled as well.
