### PR TITLE
using NetdataBot token for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
       - master
     paths:
       - charts/**
+env:
+  GITHUB_TOKEN: ${{ secrets.NETDATABOT_GITHUB_TOKEN }}
 
 jobs:
   release:
@@ -16,6 +18,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          token: ${{ env.GITHUB_TOKEN }}
 
       - name: Prepare Environment
         run: pip3 install ruamel-yaml semver


### PR DESCRIPTION
Using the Netdata bOT token to be able to push back on protected branch, I've tested it in my forked repo including the correct branch settings 
`NETDATABOT_GITHUB_TOKEN` secret already in place 