### PR TITLE
remove unused resources from ClusterRole

### DIFF
--- a/charts/netdata/templates/clusterrole.yaml
+++ b/charts/netdata/templates/clusterrole.yaml
@@ -11,7 +11,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources:
-      - "pods"        # used by sd and cgroup-name.sh
+      - "pods"        # used by sd, netdata (cgroup-name.sh, get-kubernetes-labels.sh)
       - "services"    # used by sd
       - "configmaps"  # used by sd
       - "secrets"     # used by sd
@@ -21,7 +21,7 @@ rules:
       - "watch"
   - apiGroups: [""]
     resources:
-      - "namespaces"  # used by cgroup-name.sh
+      - "namespaces"  # used by netdata (cgroup-name.sh, get-kubernetes-labels.sh)
     verbs:
       - "get"
   {{- end -}}

--- a/charts/netdata/templates/clusterrole.yaml
+++ b/charts/netdata/templates/clusterrole.yaml
@@ -11,40 +11,17 @@ metadata:
 rules:
   - apiGroups: [""]
     resources:
-      - "nodes"
-      - "pods"
-      - "services"
-      - "endpoints"
-      - "configmaps"
-      - "secrets"
-      - "events"
-      - "componentstatuses"
-      - "nodes/proxy"
+      - "pods"        # used by sd and cgroup-name.sh
+      - "services"    # used by sd
+      - "configmaps"  # used by sd
+      - "secrets"     # used by sd
     verbs:
       - "get"
       - "list"
       - "watch"
   - apiGroups: [""]
     resources:
-      - "namespaces"
-      - "resourcequotas"
-    verbs:
-      - "get"
-      - "list"
-  - apiGroups: [""]
-    resources:
-      - "nodes/metrics"
-      - "nodes/spec"
-    verbs:
-      - "get"
-  - apiGroups: ["extensions"]
-    resources:
-      - "ingresses"
-    verbs:
-      - "get"
-      - "list"
-      - "watch"
-  - nonResourceURLs: ["/version", "/healthz", "/metrics"]
+      - "namespaces"  # used by cgroup-name.sh
     verbs:
       - "get"
   {{- end -}}


### PR DESCRIPTION
Related to #148

ssia, I don't know why we have so many resources in our ClusterRole. I guess it was copy/paste from some other helmchart 🤷‍♂️ 

I tested these changes in my GKE cluster, no problems were observed:
 - cgroups name resolution works ([cgroup-name.sh](https://github.com/netdata/netdata/blob/9676eff1bc6dfc28e8f1c4857786ec05613b2646/collectors/cgroups.plugin/cgroup-name.sh.in#L216-L246))
 - pod labels are in host_labels ([get-kubernetes-labels.sh](https://github.com/netdata/netdata/blob/master/daemon/get-kubernetes-labels.sh.in))
 - no errors in service discovery container logs