### PR TITLE
[skip ci] increasing version to align with the release

### DIFF
--- a/charts/netdata/Chart.yaml
+++ b/charts/netdata/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netdata
-version: 3.7.1
+version: 3.7.2
 description: Real-time performance monitoring, done right!
 type: application
 keywords:

--- a/charts/netdata/README.md
+++ b/charts/netdata/README.md
@@ -1,6 +1,6 @@
 # Netdata Helm chart for Kubernetes deployments
 
-[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/netdata)](https://artifacthub.io/packages/search?repo=netdata) ![Version: 3.7.1](https://img.shields.io/badge/Version-3.7.1-informational) ![AppVersion: v1.31.0](https://img.shields.io/badge/AppVersion-v1.31.0-informational)
+[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/netdata)](https://artifacthub.io/packages/search?repo=netdata) ![Version: 3.7.2](https://img.shields.io/badge/Version-3.7.2-informational) ![AppVersion: v1.31.0](https://img.shields.io/badge/AppVersion-v1.31.0-informational)
 
 _Based on the work of varyumin (https://github.com/varyumin/netdata)_.
 


### PR DESCRIPTION
Since this [Action](https://github.com/netdata/helmchart/actions/runs/1438920238) failed before committing back the files into `master` currently we release `3.7.2` and didn't bump it.
This PR should align the version documented to the one released

Expecting No version bump once merged

Sorry for the aftermath 