### PR TITLE
mount /etc/os-release

### DIFF
--- a/charts/netdata/templates/daemonset.yaml
+++ b/charts/netdata/templates/daemonset.yaml
@@ -139,6 +139,8 @@ spec:
               mountPath: /var/run/docker.sock
             - name: sys
               mountPath: /host/sys
+            - name: os-release
+              mountPath: /host/etc/os-release
             {{- range $name, $config := .Values.child.configs }}
             {{- if $config.enabled }}
             - name: config
@@ -205,6 +207,9 @@ spec:
         - name: sys
           hostPath:
             path: /sys
+        - name: os-release
+          hostPath:
+            path: /etc/os-release
         - name: config
           configMap:
             name: netdata-conf-child

--- a/charts/netdata/templates/deployment.yaml
+++ b/charts/netdata/templates/deployment.yaml
@@ -99,6 +99,8 @@ spec:
             successThreshold: {{ .Values.parent.readinessProbe.successThreshold }}
             timeoutSeconds: {{ .Values.parent.readinessProbe.timeoutSeconds }}
           volumeMounts:
+            - name: os-release
+              mountPath: /host/etc/os-release
             {{- range $name, $config := .Values.parent.configs }}
             {{- if $config.enabled }}
             - name: config
@@ -130,6 +132,9 @@ spec:
     {{- end }}
       terminationGracePeriodSeconds: {{ .Values.parent.terminationGracePeriodSeconds }}
       volumes:
+        - name: os-release
+          hostPath:
+            path: /etc/os-release
         - name: config
           configMap:
             name: netdata-conf-parent


### PR DESCRIPTION
Otherwise, the host OS is "Uknown".

(Partially) fixes netdata/product#2609

<details>
<summary>Before this PR</summary>

```json
	"os_name": "unknown",
	"os_id": "unknown",
	"os_id_like": "unknown",
	"os_version": "unknown",
	"os_version_id": "unknown",
	"os_detection": "unknown",
	"cores_total": "1",
	"total_disk_space": "107374182400",
	"cpu_freq": "2299000000",
	"ram_total": "1766522880",
	"container_os_name": "Alpine Linux",
	"container_os_id": "alpine",
	"container_os_id_like": "unknown",
	"container_os_version": "unknown",
	"container_os_version_id": "3.12.8",
```
</details>

<details>
<summary>After</summary>

```json
	"os_name": "Container-Optimized OS",
	"os_id": "cos",
	"os_id_like": "unknown",
	"os_version": "85",
	"os_version_id": "85",
	"os_detection": "/host/etc/os-release",
	"cores_total": "1",
	"total_disk_space": "107374182400",
	"cpu_freq": "2299000000",
	"ram_total": "1766522880",
	"container_os_name": "Alpine Linux",
	"container_os_id": "alpine",
	"container_os_id_like": "unknown",
	"container_os_version": "unknown",
	"container_os_version_id": "3.12.9",
	"container_os_detection": "/etc/os-release",
```

</details>


---

I've tested this PR by installing it in my testing GKE cluster.