### PR TITLE
increase prometheus collector max_time_series limit to 4k

### DIFF
--- a/charts/netdata/sdconfig/child.yml
+++ b/charts/netdata/sdconfig/child.yml
@@ -106,7 +106,7 @@ build:
             url: http://{{.Address}}{{$path}}
             app: '{{.ContName}}'
             update_every: 10
-            max_time_series: 1000
+            max_time_series: 3000
   - name: "Applications"
     selector: '!unknown applications'
     tags: file

--- a/charts/netdata/sdconfig/child.yml
+++ b/charts/netdata/sdconfig/child.yml
@@ -106,7 +106,7 @@ build:
             url: http://{{.Address}}{{$path}}
             app: '{{.ContName}}'
             update_every: 10
-            max_time_series: 3000
+            max_time_series: 4000
   - name: "Applications"
     selector: '!unknown applications'
     tags: file


### PR DESCRIPTION
Was investigating why we have no some of our cloud services monitored and found the cause - the amount of returned time series > the limit.