### PR TITLE
fix: bump version of repo-sync to v2.6.2

### DIFF
--- a/.github/workflows/agent-pr.yml
+++ b/.github/workflows/agent-pr.yml
@@ -38,7 +38,7 @@ jobs:
           commit-message: 'Update agent version to ${{ github.event.inputs.agent_version }}.'
           ref: refs/heads/agent-${{ github.event.inputs.agent_version }}
       - name: Create PR
-        uses: repo-sync/pull-request@v2
+        uses: repo-sync/pull-request@v2.6.2
         with:
           source_branch: agent-${{ github.event.inputs.agent_version }}
           pr_title: 'Update agent version to ${{ github.event.inputs.agent_version }}'


### PR DESCRIPTION
GitHub release a security patch that broke this action we are using to  create PR. [Ref](https://github.com/repo-sync/pull-request/issues/84)
A fix has been introduced in the mentioned action