### PR TITLE
Add nodes/metrics ressource in clusterRole

### DIFF
--- a/charts/netdata/templates/clusterrole.yaml
+++ b/charts/netdata/templates/clusterrole.yaml
@@ -11,12 +11,12 @@ metadata:
 rules:
   - apiGroups: [""]
     resources:
-      - "pods"        # used by sd, netdata (cgroup-name.sh, get-kubernetes-labels.sh)
-      - "services"    # used by sd
-      - "configmaps"  # used by sd
-      - "secrets"     # used by sd
-      - "nodes"       # used by go.d.plugin (k8s_state)
-      - "nodes/metrics"       # used by go.d.plugin (k8s_kubelet)
+      - "pods"           # used by sd, netdata (cgroup-name.sh, get-kubernetes-labels.sh)
+      - "services"       # used by sd
+      - "configmaps"     # used by sd
+      - "secrets"        # used by sd
+      - "nodes"          # used by go.d.plugin (k8s_state)
+      - "nodes/metrics"  # used by go.d.plugin (k8s_kubelet)
     verbs:
       - "get"
       - "list"

--- a/charts/netdata/templates/clusterrole.yaml
+++ b/charts/netdata/templates/clusterrole.yaml
@@ -16,6 +16,7 @@ rules:
       - "configmaps"  # used by sd
       - "secrets"     # used by sd
       - "nodes"       # used by go.d.plugin (k8s_state)
+      - "nodes/metrics"       # used by go.d.plugin (k8s_kubelet)
     verbs:
       - "get"
       - "list"

--- a/charts/netdata/templates/clusterrole.yaml
+++ b/charts/netdata/templates/clusterrole.yaml
@@ -16,7 +16,7 @@ rules:
       - "configmaps"     # used by sd
       - "secrets"        # used by sd
       - "nodes"          # used by go.d.plugin (k8s_state)
-      - "nodes/metrics"  # used by go.d.plugin (k8s_kubelet)
+      - "nodes/metrics"  # used by go.d.plugin (k8s_kubelet) when querying kubelet's HTTPS endpoint
     verbs:
       - "get"
       - "list"


### PR DESCRIPTION
Required for go.d/k8s_kubelet when kubelet's insecure endpoint is disabled