### PR TITLE
feat: add http basic auth to data collection jobs created by service discovery

### DIFF
--- a/charts/netdata/sdconfig/child.yml
+++ b/charts/netdata/sdconfig/child.yml
@@ -202,6 +202,8 @@ build:
           - module: rabbitmq
             name: rabbitmq-{{.TUID}}
             url: http://{{.Address}}
+            username: "{{ get .Env "NETDATA_SD_AUTH_USER" }}"
+            password: "{{ get .Env "NETDATA_SD_AUTH_PASS" }}"
       - selector: solr
         template: |
           - module: solr


### PR DESCRIPTION
Fixes: #279

The idea is to use `NETDATA_SD_AUTH_USER`, `NETDATA_SD_AUTH_PASS` env variables values for HTTP basic auth in collectors.