### PR TITLE
Fixes: cannot overwrite table with non table

### DIFF
--- a/charts/netdata/values.yaml
+++ b/charts/netdata/values.yaml
@@ -22,7 +22,7 @@ sd:
       # if 'from' is {} the ConfigMap is not generated
       from:
         file: sdconfig/child.yml
-        value: {}
+        value: null
     resources:
       limits:
         cpu: 50m


### PR DESCRIPTION
Reproduce:
helm upgrade -i netdata netdata/netdata -f ./values.yaml --set-file sd.child.configmap.from.value=./child.yml --namespace netdata --create-namespace --wait --atomic
coalesce.go:220: warning: cannot overwrite table with non table for netdata.sd.child.configmap.from.value (map[])