### PR TITLE
disable ML on children instances

### DIFF
--- a/charts/netdata/values.yaml
+++ b/charts/netdata/values.yaml
@@ -272,6 +272,8 @@ child:
           memory mode = ram
         [health]
           enabled = no
+        [ml]
+          enabled = no
     stream:
       enabled: true
       path: /etc/netdata/stream.conf


### PR DESCRIPTION
- we [enabled by default](https://github.com/netdata/netdata/pull/13158)
- we want to enable ML only on parent instances