### PR TITLE
chore: bump sd image version to v0.2.5

### DIFF
--- a/charts/netdata/values.yaml
+++ b/charts/netdata/values.yaml
@@ -12,7 +12,7 @@ image:
 sd:
   image:
     repository: netdata/agent-sd
-    tag: v0.2.4
+    tag: v0.2.5
     pullPolicy: Always
   child:
     enabled: true


### PR DESCRIPTION
This PR bumps the sd image to [v0.2.5](https://github.com/netdata/agent-service-discovery/releases/tag/v0.2.5) which fixes some [vulnerabilities in netdata/agent-sd:v0.2.4](https://artifacthub.io/packages/helm/netdata/netdata?modal=security-report).