### PR TITLE
remove the non-working parameter "notifications"

### DIFF
--- a/charts/netdata/README.md
+++ b/charts/netdata/README.md
@@ -141,7 +141,7 @@ The following table lists the configurable parameters of the netdata chart and t
 | `parent.claiming.room`                     | Comma separated list of claim rooms IDs                                                                                                                | `""`                                                                                    |
 | `parent.extraVolumeMounts`                 | Additional volumeMounts to add to the parent pods                                                                                                      | `[]`                                                                                    |
 | `parent.extraVolumes`                      | Additional volumes to add to the parent pods                                                                                                           | `[]`                                                                                    |
-| `k8sState.enabled`                         | Install this Deployment to gather data fr K8s cluster                                                                                                  | `yes`                                                                                 |
+| `k8sState.enabled`                         | Install this Deployment to gather data fr K8s cluster                                                                                                  | `yes`                                                                                   |
 | `k8sState.port`                            | Listen port                                                                                                                                            | `service.port` (Same as parent's listen port)                                           |
 | `k8sState.resources`                       | Compute resources required by this Deployment                                                                                                          | `{}`                                                                                    |
 | `k8sState.livenessProbe.failureThreshold`  | When a liveness probe fails, Kubernetes will try failureThreshold times before giving up. Giving up the liveness probe means restarting the container  | `3`                                                                                     |
@@ -205,8 +205,6 @@ The following table lists the configurable parameters of the netdata chart and t
 | `child.claiming.room`                      | Comma separated list of claim rooms IDs                                                                                                                | `""`                                                                                    |
 | `child.extraVolumeMounts`                  | Additional volumeMounts to add to the child pods                                                                                                       | `[]`                                                                                    |
 | `child.extraVolumes`                       | Additional volumes to add to the child pods                                                                                                            | `[]`                                                                                    |
-| `notifications.slackurl`                   | URL for slack notifications                                                                                                                            | `""`                                                                                    |
-| `notifications.slackrecipient`             | Slack recipient list                                                                                                                                   | `""`                                                                                    |
 | `initContainersImage.repository`           | Init containers' image repository                                                                                                                      | `alpine`                                                                                |
 | `initContainersImage.tag`                  | Init containers' image tag                                                                                                                             | `latest`                                                                                |
 | `initContainersImage.pullPolicy`           | Init containers' image pull policy                                                                                                                     | `Always`                                                                                |
@@ -227,8 +225,7 @@ Example to set the parameters from the command line:
 
 ```console
 $ helm install ./netdata --name my-release \
-    --set notifications.slackurl=MySlackAPIURL \
-    --set notifications.slackrecipiet="@MyUser MyChannel"
+    --set image.tag=latest
 ```
 
 Another example, to set a different ingress controller.

--- a/charts/netdata/values.yaml
+++ b/charts/netdata/values.yaml
@@ -177,15 +177,15 @@ parent:
       path: /etc/netdata/health_alarm_notify.conf
       data: |
         SEND_EMAIL="NO"
-        SEND_SLACK="YES"
-        SLACK_WEBHOOK_URL=""
-        DEFAULT_RECIPIENT_SLACK=""
-        role_recipients_slack[sysadmin]="${DEFAULT_RECIPIENT_SLACK}"
-        role_recipients_slack[domainadmin]="${DEFAULT_RECIPIENT_SLACK}"
-        role_recipients_slack[dba]="${DEFAULT_RECIPIENT_SLACK}"
-        role_recipients_slack[webmaster]="${DEFAULT_RECIPIENT_SLACK}"
-        role_recipients_slack[proxyadmin]="${DEFAULT_RECIPIENT_SLACK}"
-        role_recipients_slack[sitemgr]="${DEFAULT_RECIPIENT_SLACK}"
+        # SEND_SLACK="YES"
+        # SLACK_WEBHOOK_URL="MySlackAPIURL"
+        # DEFAULT_RECIPIENT_SLACK="@MyUser MyChannel"
+        # role_recipients_slack[sysadmin]="${DEFAULT_RECIPIENT_SLACK}"
+        # role_recipients_slack[domainadmin]="${DEFAULT_RECIPIENT_SLACK}"
+        # role_recipients_slack[dba]="${DEFAULT_RECIPIENT_SLACK}"
+        # role_recipients_slack[webmaster]="${DEFAULT_RECIPIENT_SLACK}"
+        # role_recipients_slack[proxyadmin]="${DEFAULT_RECIPIENT_SLACK}"
+        # role_recipients_slack[sitemgr]="${DEFAULT_RECIPIENT_SLACK}"
     exporting:
       enabled: false
       path: /etc/netdata/exporting.conf


### PR DESCRIPTION
That is an alternative to #300. To my understanding both `notifications.slackurl` and `notifications.slackrecipient` have never been working because 

https://github.com/netdata/helmchart/blob/fb004a60d8c72349a0e9ba65c9a7401bb1ec20a1/charts/netdata/values.yaml#L181-L182

If we need this functionality (which I doubt) we need to close this PR and merge #300.