### PR TITLE
bump agent sd version to v0.2.7

### DIFF
--- a/charts/netdata/values.yaml
+++ b/charts/netdata/values.yaml
@@ -12,7 +12,7 @@ image:
 sd:
   image:
     repository: netdata/agent-sd
-    tag: v0.2.6
+    tag: v0.2.7
     pullPolicy: Always
   child:
     enabled: true


### PR DESCRIPTION
This PR bumps the sd image to [v0.2.7](https://github.com/netdata/agent-service-discovery/releases/tag/v0.2.7).

The only change is using the latest stable alpine image (v3.17.0).