### PR TITLE
bump agent-sd to v0.2.8

### DIFF
--- a/charts/netdata/values.yaml
+++ b/charts/netdata/values.yaml
@@ -12,7 +12,7 @@ image:
 sd:
   image:
     repository: netdata/agent-sd
-    tag: v0.2.7
+    tag: v0.2.8
     pullPolicy: Always
   child:
     enabled: true


### PR DESCRIPTION
ssia, bump to [v0.2.8](https://github.com/netdata/agent-service-discovery/releases/tag/v0.2.8)