### PR TITLE
feat: add netdata-restarter cronjob

### DIFF
--- a/charts/netdata/README.md
+++ b/charts/netdata/README.md
@@ -121,6 +121,17 @@ The following table lists the configurable parameters of the netdata chart and t
 | `serviceAccount.name`                      | The name of the service account to use. If not set and create is true, a name is generated using the fullname template.                                | `netdata`                                                                               |
 | `clusterrole.name`                         | Name of the cluster role linked with the service account                                                                                               | `netdata`                                                                               |
 | `APIKEY`                                   | The key shared between the parent and the child netdata for streaming                                                                                  | `11111111-2222-3333-4444-555555555555`                                                  |
+| `restarter.enabled`                        | Install CronJob to update Netdata Pods                                                                                                                 | `false`                                                                                 |
+| `restarter.schedule`                       | The schedule in Cron format                                                                                                                            | `00 06 * * *`                                                                           |
+| `restarter.image.repository`               | Container image repo                                                                                                                                   | `bitnami/kubectl`                                                                       |
+| `restarter.image.tag`                      | Container image tag                                                                                                                                    | `1.25`                                                                                  |
+| `restarter.image.pullPolicy`               | Container image pull policy                                                                                                                            | `Always`                                                                                |
+| `restarter.image.restartPolicy`            | Container restart policy                                                                                                                               | `Never`                                                                                 |
+| `restarter.image.resources`                | Container resources                                                                                                                                    | `{}`                                                                                    |
+| `restarter.concurrencyPolicy`              | Specifies how to treat concurrent executions of a job                                                                                                  | `Forbid`                                                                                |
+| `restarter.startingDeadlineSeconds`        | Optional deadline in seconds for starting the job if it misses scheduled time for any reason                                                           | `60`                                                                                    |
+| `restarter.successfulJobsHistoryLimit`     | The number of successful finished jobs to retain                                                                                                       | `3`                                                                                     |
+| `restarter.failedJobsHistoryLimit`         | The number of failed finished jobs to retain                                                                                                           | `3`                                                                                     |
 | `parent.enabled`                           | Install parent Deployment to receive metrics from children nodes                                                                                       | `true`                                                                                  |
 | `parent.port`                              | Parent's listen port                                                                                                                                   | `19999`                                                                                 |
 | `parent.resources`                         | Resources for the parent deployment                                                                                                                    | `{}`                                                                                    |
@@ -264,9 +275,9 @@ $ helm install ./netdata --name my-release -f values.yaml
 > **Tip**: You can use the default [values.yaml](values.yaml)
 
 > **Note:**: To opt out of anonymous statistics, set the `DO_NOT_TRACK`
-environment variable to non-zero or non-empty value in
+> environment variable to non-zero or non-empty value in
 `parent.env` / `child.env` configuration (e.g: `DO_NOT_TRACK: 1`)
-or uncomment the line in `values.yml`.
+> or uncomment the line in `values.yml`.
 
 ### Configuration files
 
@@ -298,7 +309,7 @@ not collect much data. As a result, the only other configuration files that migh
 the alarm and alarm template definitions, under `/etc/netdata/health.d`.
 
 > **Tip**: Do pay attention to the indentation of the config file contents, as it matters for the parsing of the `yaml` file. Note that the first line under `var: |`
-must be indented with two more spaces relative to the preceding line:
+> must be indented with two more spaces relative to the preceding line:
 
 ```
   data: |-

--- a/charts/netdata/README.md
+++ b/charts/netdata/README.md
@@ -22,6 +22,9 @@ By default, the chart installs:
  - A Netdata k8s state monitoring pod on one node, using a `Deployment`. This virtual node is called `netdata-k8s-state`.
  - A Netdata parent pod on one node, using a `Deployment`. This virtual node is called `netdata-parent`.
 
+Disabled by default:
+- A Netdata restarter `CronJob`. Its main purpose is to automatically update Netdata when using nightly releases.
+
 The child pods and the state pod function as headless collectors that collect and forward
 all the metrics to the parent pod. The parent pod uses persistent volumes to store metrics and alarms, handle alarm
 notifications, and provide the Netdata UI to view metrics using an ingress controller.

--- a/charts/netdata/templates/_helpers.tpl
+++ b/charts/netdata/templates/_helpers.tpl
@@ -52,3 +52,14 @@ Return the appropriate apiVersion for ingress.
 {{- "networking.k8s.io/v1" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return a value indicating whether the restarte is enabled.
+*/}}
+{{- define "netdata.restarter.enabled" -}}
+{{- if and .Values.restarter.enabled (or .Values.parent.enabled .Values.child.enabled .Values.k8sState.enabled) }}
+{{- "true" -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/netdata/templates/_helpers.tpl
+++ b/charts/netdata/templates/_helpers.tpl
@@ -54,7 +54,7 @@ Return the appropriate apiVersion for ingress.
 {{- end -}}
 
 {{/*
-Return a value indicating whether the restarte is enabled.
+Return a value indicating whether the restarter is enabled.
 */}}
 {{- define "netdata.restarter.enabled" -}}
 {{- if and .Values.restarter.enabled (or .Values.parent.enabled .Values.child.enabled .Values.k8sState.enabled) }}

--- a/charts/netdata/templates/_helpers.tpl
+++ b/charts/netdata/templates/_helpers.tpl
@@ -57,7 +57,7 @@ Return the appropriate apiVersion for ingress.
 Return a value indicating whether the restarter is enabled.
 */}}
 {{- define "netdata.restarter.enabled" -}}
-{{- if and .Values.restarter.enabled (or .Values.parent.enabled .Values.child.enabled .Values.k8sState.enabled) }}
+{{- if and .Values.restarter.enabled (eq .Values.image.pullPolicy "Always") (or .Values.parent.enabled .Values.child.enabled .Values.k8sState.enabled) }}
 {{- "true" -}}
 {{- else -}}
 {{- "" -}}

--- a/charts/netdata/templates/cronjob.yaml
+++ b/charts/netdata/templates/cronjob.yaml
@@ -24,6 +24,10 @@ spec:
         spec:
           serviceAccountName: {{ .Values.serviceAccount.name }}-restarter
           restartPolicy: {{ .Values.restarter.restartPolicy }}
+          {{- if .Values.imagePullSecrets }}
+          imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 12 }}
+          {{- end }}
           containers:
             - name: netdata-restarter
               image: {{ .Values.restarter.image.repository }}:{{ .Values.restarter.image.tag }}

--- a/charts/netdata/templates/cronjob.yaml
+++ b/charts/netdata/templates/cronjob.yaml
@@ -1,0 +1,37 @@
+{{- if include "netdata.restarter.enabled" . }}
+---
+{{- $cmdList := list }}
+{{- $cmd := printf "kubectl rollout restart deployment %s-parent" (include "netdata.name" .) }}
+{{- $cmdList = append $cmdList (ternary $cmd "" .Values.parent.enabled) }}
+{{- $cmd = printf "kubectl rollout restart daemonset %s-child" (include "netdata.name" .) }}
+{{- $cmdList = append $cmdList (ternary $cmd "" .Values.child.enabled) }}
+{{- $cmd = printf "kubectl rollout restart deployment %s-k8s-state" (include "netdata.name" .) }}
+{{- $cmdList = append $cmdList (ternary $cmd "" .Values.k8sState.enabled) }}
+{{- $cmdList = compact $cmdList }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ template "netdata.name" . }}-restarter
+spec:
+  schedule: "{{ .Values.restarter.schedule }}"
+  concurrencyPolicy: {{ .Values.restarter.concurrencyPolicy }}
+  startingDeadlineSeconds: {{ .Values.restarter.startingDeadlineSeconds }}
+  successfulJobsHistoryLimit: {{ .Values.restarter.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.restarter.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: {{ .Values.serviceAccount.name }}-restarter
+          restartPolicy: {{ .Values.restarter.restartPolicy }}
+          containers:
+            - name: netdata-restarter
+              image: {{ .Values.restarter.image.repository }}:{{ .Values.restarter.image.tag }}
+              imagePullPolicy: {{ .Values.restarter.image.pullPolicy }}
+              resources:
+{{ toYaml .Values.restarter.resources | indent 16 }}
+              command:
+                - "/bin/bash"
+                - "-c"
+                - {{ $cmdList | join " && " }}
+{{- end }}

--- a/charts/netdata/templates/role.yml
+++ b/charts/netdata/templates/role.yml
@@ -1,0 +1,25 @@
+{{- if and .Values.serviceAccount.create (include "netdata.restarter.enabled" .) }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "netdata.fullname" . }}-restarter
+  labels:
+    app: {{ template "netdata.name" . }}
+    chart: {{ template "netdata.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+  - apiGroups:
+      - "apps"
+    resources:
+      - "deployments"
+      - "daemonsets"
+    resourceNames:
+      - {{ template "netdata.name" . }}-parent
+      - {{ template "netdata.name" . }}-child
+      - {{ template "netdata.name" . }}-k8s-state
+    verbs:
+      - "get"
+      - "patch"
+{{- end -}}

--- a/charts/netdata/templates/rolebinding.yaml
+++ b/charts/netdata/templates/rolebinding.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.serviceAccount.create (include "netdata.restarter.enabled" .) }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "netdata.fullname" . }}-restarter
+  labels:
+    app: {{ template "netdata.name" . }}
+    chart: {{ template "netdata.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "netdata.fullname" . }}-restarter
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.serviceAccount.name }}-restarter
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/charts/netdata/templates/serviceaccount.yaml
+++ b/charts/netdata/templates/serviceaccount.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.serviceAccount.create -}}
+---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
@@ -8,4 +9,17 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   name: {{ .Values.serviceAccount.name }}
+{{- end -}}
+
+{{- if and .Values.serviceAccount.create (include "netdata.restarter.enabled" .) }}
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  labels:
+    app: {{ template "netdata.name" . }}
+    chart: {{ template "netdata.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name: {{ .Values.serviceAccount.name }}-restarter
 {{- end -}}

--- a/charts/netdata/values.yaml
+++ b/charts/netdata/values.yaml
@@ -9,26 +9,6 @@ image:
   tag: "{{ .Chart.AppVersion }}"
   pullPolicy: Always
 
-restarter:
-  enabled: true
-  schedule: "00 06 * * *"
-  image:
-    repository: bitnami/kubectl
-    tag: 1.25
-    pullPolicy: Always
-  restartPolicy: Never
-  resources: {}
-    # limits:
-    #  cpu: 500m
-    #  memory: 64Mi
-    # requests:
-    #  cpu: 250m
-    #  memory: 32Mi
-  concurrencyPolicy: Forbid
-  startingDeadlineSeconds: 60
-  successfulJobsHistoryLimit: 3
-  failedJobsHistoryLimit: 3
-
 sd:
   image:
     repository: netdata/agent-sd
@@ -100,6 +80,25 @@ serviceAccount:
   create: true
   name: netdata
 
+restarter:
+  enabled: true
+  schedule: "00 06 * * *"
+  image:
+    repository: bitnami/kubectl
+    tag: 1.25
+    pullPolicy: Always
+  restartPolicy: Never
+  resources: {}
+    # limits:
+    #  cpu: 500m
+    #  memory: 64Mi
+    # requests:
+    #  cpu: 250m
+  #  memory: 32Mi
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 60
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
 
 parent:
   enabled: true

--- a/charts/netdata/values.yaml
+++ b/charts/netdata/values.yaml
@@ -9,6 +9,26 @@ image:
   tag: "{{ .Chart.AppVersion }}"
   pullPolicy: Always
 
+restarter:
+  enabled: true
+  schedule: "00 06 * * *"
+  image:
+    repository: bitnami/kubectl
+    tag: 1.25
+    pullPolicy: Always
+  restartPolicy: Never
+  resources: {}
+    # limits:
+    #  cpu: 500m
+    #  memory: 64Mi
+    # requests:
+    #  cpu: 250m
+    #  memory: 32Mi
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 60
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+
 sd:
   image:
     repository: netdata/agent-sd

--- a/charts/netdata/values.yaml
+++ b/charts/netdata/values.yaml
@@ -81,7 +81,7 @@ serviceAccount:
   name: netdata
 
 restarter:
-  enabled: true
+  enabled: false
   schedule: "00 06 * * *"
   image:
     repository: bitnami/kubectl


### PR DESCRIPTION
This PR adds netdata restarter cronjob. Implements the 2nd item from #337.

Tested on local k8s cluster.