### PR TITLE
add nodes/proxy to clusterrole

### DIFF
--- a/charts/netdata/templates/clusterrole.yaml
+++ b/charts/netdata/templates/clusterrole.yaml
@@ -16,7 +16,8 @@ rules:
       - "configmaps"     # used by sd
       - "secrets"        # used by sd
       - "nodes"          # used by go.d/k8s_state
-      - "nodes/metrics"  # used by go.d/k8s_state when querying Kubelet HTTPS endpoint
+      - "nodes/metrics"  # used by go.d/k8s_kubelet when querying Kubelet HTTPS endpoint
+      - "nodes/proxy"    # used by netdata (cgroup-name.sh) when querying Kubelet /pods endpoint
     verbs:
       - "get"
       - "list"


### PR DESCRIPTION
This is needed to gather Pods metadata from Kubelet. See netdata/netdata#14843.