### PR TITLE
Replace deprecated set-output with ...>> $GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           changed=$(ct list-changed)
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Run chart-testing (lint)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,14 +31,14 @@ jobs:
 
       - name: Get current version
         id: get_current_var
-        run: echo ::set-output name=current_version::$(.github/scripts/update_versions.py get_chart_version)
+        run: echo "current_version=$(.github/scripts/update_versions.py get_chart_version)" >> $GITHUB_OUTPUT
 
       - name: Update Files
         run: .github/scripts/update_versions.py set_chart_version
 
       - name: Get the new version
         id: new_version_var
-        run: echo ::set-output name=new_version::$(.github/scripts/update_versions.py get_chart_version)
+        run: echo "new_version=$(.github/scripts/update_versions.py get_chart_version)" >> $GITHUB_OUTPUT
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.5.0


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

TL;DR

> name: Save state
> run: echo "::save-state name={name}::{value}"
> 
> name: Set output
> run: echo "::set-output name={name}::{value}"
> 
> name: Save state
> run: echo "{name}={value}" >> $GITHUB_STATE
> 
> name: Set output
> run: echo "{name}={value}" >> $GITHUB_OUTPUT

Ref: https://github.com/netdata/infra/issues/3541