### PR TITLE
Revert "increase sd prometheus max_time_series"

### DIFF
--- a/charts/netdata/sdconfig/child.yml
+++ b/charts/netdata/sdconfig/child.yml
@@ -112,8 +112,7 @@ build:
             url: http://{{.Address}}{{$path}}
             app: '{{.ContName}}'
             update_every: 10
-            max_time_series: 20000
-            max_time_series_per_metric: 1000
+            max_time_series: 4000
   - name: "Applications"
     selector: '!unknown applications'
     tags: file


### PR DESCRIPTION
Reverts netdata/helmchart#357

This can result is really a lot of metrics => and much bigger memory requirements. Should be a configuration option (in values), not default.