### PR TITLE
feat: add option to store configuration as secrets

### DIFF
--- a/charts/netdata/README.md
+++ b/charts/netdata/README.md
@@ -303,7 +303,9 @@ To deploy additional netdata user configuration files, you will need to add simi
 the `parent.configs` or the `child.configs` arrays. Regardless of whether you add config files that reside directly
 under `/etc/netdata` or in a subdirectory such as `/etc/netdata/go.d`, you can use the already provided configurations
 as reference. For reference, the `parent.configs` the array includes an `example` alarm that would get triggered if the
-python.d `example` module was enabled.
+python.d `example` module was enabled. Whenever you pass the sensitive data to your configuration like the database
+credential you can take an option to put it into the Kubernetes Secret by specifying `storedType: secret` in the
+selected configuration. Default all the configuration will be placed in the Kubernetes configmap.
 
 Note that with the default configuration of this chart, the parent does the health checks and triggers alarms, but does
 not collect much data. As a result, the only other configuration files that might make sense to add to the parent are

--- a/charts/netdata/templates/_helpers.tpl
+++ b/charts/netdata/templates/_helpers.tpl
@@ -93,8 +93,6 @@ Return the configmap data for the child configuration. Configmap is the default 
 {{- $found = true -}}
 {{- else if and $config.enabled (ne $config.storedType "secret") -}}
 {{- $found = true -}}
-{{- else if and $config.enabled (not $config.storedType) -}}
-{{- $found = true -}}
 {{- end -}}
 {{- if $found }}
 {{ $name }}: {{ tpl $config.data $ | toYaml | indent 4 | trim }}
@@ -111,8 +109,6 @@ Return the configmap data for the k8s state configuration. Configmap is the defa
 {{- if and $config.enabled (eq $config.storedType "configmap") -}}
 {{- $found = true -}}
 {{- else if and $config.enabled (ne $config.storedType "secret") -}}
-{{- $found = true -}}
-{{- else if and $config.enabled (not $config.storedType) -}}
 {{- $found = true -}}
 {{- end -}}
 {{- if $found }}

--- a/charts/netdata/templates/_helpers.tpl
+++ b/charts/netdata/templates/_helpers.tpl
@@ -63,3 +63,93 @@ Return a value indicating whether the restarter is enabled.
 {{- "" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the configmap data for the parent configuration. Configmap is the default choice for storing configuration.
+*/}}
+{{- define "netdata.parent.configs.configmap" -}}
+{{- range $name, $config := .Values.parent.configs -}}
+{{- $found := false -}}
+{{- if and $config.enabled (eq $config.storedType "configmap") -}}
+{{- $found = true -}}
+{{- else if and $config.enabled (ne $config.storedType "secret") -}}
+{{- $found = true -}}
+{{- else if and $config.enabled (not $config.storedType) -}}
+{{- $found = true -}}
+{{- end -}}
+{{- if $found }}
+{{ $name }}: {{ tpl $config.data $ | toYaml | indent 4 | trim }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the configmap data for the child configuration. Configmap is the default choice for storing configuration.
+*/}}
+{{- define "netdata.child.configs.configmap" -}}
+{{- range $name, $config := .Values.child.configs -}}
+{{- $found := false -}}
+{{- if and $config.enabled (eq $config.storedType "configmap") -}}
+{{- $found = true -}}
+{{- else if and $config.enabled (ne $config.storedType "secret") -}}
+{{- $found = true -}}
+{{- else if and $config.enabled (not $config.storedType) -}}
+{{- $found = true -}}
+{{- end -}}
+{{- if $found }}
+{{ $name }}: {{ tpl $config.data $ | toYaml | indent 4 | trim }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the configmap data for the k8s state configuration. Configmap is the default choice for storing configuration.
+*/}}
+{{- define "netdata.k8sState.configs.configmap" -}}
+{{- range $name, $config := .Values.k8sState.configs -}}
+{{- $found := false -}}
+{{- if and $config.enabled (eq $config.storedType "configmap") -}}
+{{- $found = true -}}
+{{- else if and $config.enabled (ne $config.storedType "secret") -}}
+{{- $found = true -}}
+{{- else if and $config.enabled (not $config.storedType) -}}
+{{- $found = true -}}
+{{- end -}}
+{{- if $found }}
+{{ $name }}: {{ tpl $config.data $ | toYaml | indent 4 | trim }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the secret data for the parent configuration, when you setup storedType as a secret.
+*/}}
+{{- define "netdata.parent.configs.secret" -}}
+{{- range $name, $config := .Values.parent.configs -}}
+{{- if and $config.enabled (eq $config.storedType "secret") }}
+{{ $name }}: {{ tpl $config.data $ | b64enc }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the secret data for the child configuration, when you setup storedType as a secret.
+*/}}
+{{- define "netdata.child.configs.secret" -}}
+{{- range $name, $config := .Values.child.configs -}}
+{{- if and $config.enabled (eq $config.storedType "secret") }}
+{{ $name }}: {{ tpl $config.data $ | b64enc }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the secret data for the k8s state configuration, when you setup storedType as a secret.
+*/}}
+{{- define "netdata.k8sState.configs.secret" -}}
+{{- range $name, $config := .Values.k8sState.configs -}}
+{{- if and $config.enabled (eq $config.storedType "secret") }}
+{{ $name }}: {{ tpl $config.data $ | b64enc }}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/netdata/templates/configmap.yaml
+++ b/charts/netdata/templates/configmap.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.parent.enabled }}
+{{- $configmapParent := include "netdata.parent.configs.configmap" . }}
+{{- if and .Values.parent.enabled $configmapParent }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -10,14 +11,11 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  {{- range $name, $config := .Values.parent.configs }}
-  {{- if $config.enabled }}
-  {{ $name }}: {{ tpl $config.data $ | toYaml | indent 4 | trim }}
-  {{- end }}
-  {{- end }}
+  {{ $configmapParent | indent 2 }}
 {{- end }}
 
-{{- if .Values.child.enabled }}
+{{- $configmapChild := include "netdata.child.configs.configmap" . }}
+{{- if and .Values.child.enabled $configmapChild}}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -29,15 +27,11 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  {{- range $name, $config := .Values.child.configs }}
-  {{- if $config.enabled }}
-  {{ $name }}: {{ tpl $config.data $ | toYaml | indent 4 | trim }}
-  {{- end }}
-  {{- end }}
+  {{ $configmapChild | indent 2 }}
 {{- end }}
 
-
-{{- if .Values.k8sState.enabled }}
+{{- $configmapk8sState := include "netdata.k8sState.configs.configmap" . }}
+{{- if and .Values.k8sState.enabled $configmapk8sState }}}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -49,11 +43,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  {{- range $name, $config := .Values.k8sState.configs }}
-  {{- if $config.enabled }}
-  {{ $name }}: {{ tpl $config.data $ | toYaml | indent 4 | trim }}
-  {{- end }}
-  {{- end }}
+  {{ $configmapk8sState | indent 2 }}
 {{- end }}
 
 

--- a/charts/netdata/templates/configmap.yaml
+++ b/charts/netdata/templates/configmap.yaml
@@ -31,7 +31,7 @@ data:
 {{- end }}
 
 {{- $configmapk8sState := include "netdata.k8sState.configs.configmap" . }}
-{{- if and .Values.k8sState.enabled $configmapk8sState }}}
+{{- if and .Values.k8sState.enabled $configmapk8sState }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/charts/netdata/templates/daemonset.yaml
+++ b/charts/netdata/templates/daemonset.yaml
@@ -158,8 +158,20 @@ spec:
             - name: os-release
               mountPath: /host/etc/os-release
             {{- range $name, $config := .Values.child.configs }}
-            {{- if $config.enabled }}
-            - name: config
+            {{- if and $config.enabled (eq $config.storedType "configmap") }}
+            - name: configmap
+              mountPath: {{ $config.path }}
+              subPath: {{ $name }}
+            {{- else if and $config.enabled (eq $config.storedType "secret") }}
+            - name: configsecret
+              mountPath: {{ $config.path }}
+              subPath: {{ $name }}
+            {{- else if and $config.enabled (ne $config.storedType "secret") }}
+            - name: configmap
+              mountPath: {{ $config.path }}
+              subPath: {{ $name }}
+            {{- else if and $config.enabled (not $config.storedType) }}
+            - name: configmap
               mountPath: {{ $config.path }}
               subPath: {{ $name }}
             {{- end }}
@@ -232,6 +244,14 @@ spec:
         - name: config
           configMap:
             name: netdata-conf-child
+        - name: configmap
+          configMap:
+            name: netdata-conf-child
+            optional: true
+        - name: configsecret
+          secret:
+            secretName: netdata-conf-child
+            optional: true
         {{- with .Values.child.persistence }}
         {{- if  and .enabled .hostPath }}
         - name: persistencevarlibdir

--- a/charts/netdata/templates/daemonset.yaml
+++ b/charts/netdata/templates/daemonset.yaml
@@ -158,20 +158,8 @@ spec:
             - name: os-release
               mountPath: /host/etc/os-release
             {{- range $name, $config := .Values.child.configs }}
-            {{- if and $config.enabled (eq $config.storedType "configmap") }}
-            - name: configmap
-              mountPath: {{ $config.path }}
-              subPath: {{ $name }}
-            {{- else if and $config.enabled (eq $config.storedType "secret") }}
-            - name: configsecret
-              mountPath: {{ $config.path }}
-              subPath: {{ $name }}
-            {{- else if and $config.enabled (ne $config.storedType "secret") }}
-            - name: configmap
-              mountPath: {{ $config.path }}
-              subPath: {{ $name }}
-            {{- else if and $config.enabled (not $config.storedType) }}
-            - name: configmap
+            {{- if $config.enabled }}
+            - name: {{ ternary "configmap" "configsecret" (ne $config.storedType "secret") }}
               mountPath: {{ $config.path }}
               subPath: {{ $name }}
             {{- end }}
@@ -241,9 +229,6 @@ spec:
         - name: os-release
           hostPath:
             path: /etc/os-release
-        - name: config
-          configMap:
-            name: netdata-conf-child
         - name: configmap
           configMap:
             name: netdata-conf-child

--- a/charts/netdata/templates/deployment.yaml
+++ b/charts/netdata/templates/deployment.yaml
@@ -114,8 +114,20 @@ spec:
             - name: os-release
               mountPath: /host/etc/os-release
             {{- range $name, $config := .Values.parent.configs }}
-            {{- if $config.enabled }}
-            - name: config
+            {{- if and $config.enabled (eq $config.storedType "configmap") }}
+            - name: configmap
+              mountPath: {{ $config.path }}
+              subPath: {{ $name }}
+            {{- else if and $config.enabled (eq $config.storedType "secret") }}
+            - name: configsecret
+              mountPath: {{ $config.path }}
+              subPath: {{ $name }}
+            {{- else if and $config.enabled (ne $config.storedType "secret") }}
+            - name: configmap
+              mountPath: {{ $config.path }}
+              subPath: {{ $name }}
+            {{- else if and $config.enabled (not $config.storedType) }}
+            - name: configmap
               mountPath: {{ $config.path }}
               subPath: {{ $name }}
             {{- end }}
@@ -150,9 +162,14 @@ spec:
         - name: os-release
           hostPath:
             path: /etc/os-release
-        - name: config
+        - name: configmap
           configMap:
             name: netdata-conf-parent
+            optional: true
+        - name: configsecret
+          secret:
+            secretName: netdata-conf-parent
+            optional: true
         {{- if .Values.parent.database.persistence }}
         - name: database
           persistentVolumeClaim:
@@ -281,8 +298,20 @@ spec:
             - name: os-release
               mountPath: /host/etc/os-release
             {{- range $name, $config := .Values.k8sState.configs }}
-            {{- if $config.enabled }}
-            - name: config
+            {{- if and $config.enabled (eq $config.storedType "configmap") }}
+            - name: configmap
+              mountPath: {{ $config.path }}
+              subPath: {{ $name }}
+            {{- else if and $config.enabled (eq $config.storedType "secret") }}
+            - name: configsecret
+              mountPath: {{ $config.path }}
+              subPath: {{ $name }}
+            {{- else if and $config.enabled (ne $config.storedType "secret") }}
+            - name: configmap
+              mountPath: {{ $config.path }}
+              subPath: {{ $name }}
+            {{- else if and $config.enabled (not $config.storedType) }}
+            - name: configmap
               mountPath: {{ $config.path }}
               subPath: {{ $name }}
             {{- end }}
@@ -311,11 +340,15 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.k8sState.terminationGracePeriodSeconds }}
       volumes:
         - name: os-release
-          hostPath:
-            path: /etc/os-release
-        - name: config
+          mountPath: /host/etc/os-release
+        - name: configmap
           configMap:
             name: netdata-conf-k8s-state
+            optional: true
+        - name: configsecret
+          secret:
+            secretName: netdata-conf-k8s-state
+            optional: true
         {{- if .Values.k8sState.persistence.enabled }}
         - name: varlib
           persistentVolumeClaim:

--- a/charts/netdata/templates/deployment.yaml
+++ b/charts/netdata/templates/deployment.yaml
@@ -114,20 +114,8 @@ spec:
             - name: os-release
               mountPath: /host/etc/os-release
             {{- range $name, $config := .Values.parent.configs }}
-            {{- if and $config.enabled (eq $config.storedType "configmap") }}
-            - name: configmap
-              mountPath: {{ $config.path }}
-              subPath: {{ $name }}
-            {{- else if and $config.enabled (eq $config.storedType "secret") }}
-            - name: configsecret
-              mountPath: {{ $config.path }}
-              subPath: {{ $name }}
-            {{- else if and $config.enabled (ne $config.storedType "secret") }}
-            - name: configmap
-              mountPath: {{ $config.path }}
-              subPath: {{ $name }}
-            {{- else if and $config.enabled (not $config.storedType) }}
-            - name: configmap
+            {{- if $config.enabled }}
+            - name: {{ ternary "configmap" "configsecret" (ne $config.storedType "secret") }}
               mountPath: {{ $config.path }}
               subPath: {{ $name }}
             {{- end }}
@@ -298,20 +286,8 @@ spec:
             - name: os-release
               mountPath: /host/etc/os-release
             {{- range $name, $config := .Values.k8sState.configs }}
-            {{- if and $config.enabled (eq $config.storedType "configmap") }}
-            - name: configmap
-              mountPath: {{ $config.path }}
-              subPath: {{ $name }}
-            {{- else if and $config.enabled (eq $config.storedType "secret") }}
-            - name: configsecret
-              mountPath: {{ $config.path }}
-              subPath: {{ $name }}
-            {{- else if and $config.enabled (ne $config.storedType "secret") }}
-            - name: configmap
-              mountPath: {{ $config.path }}
-              subPath: {{ $name }}
-            {{- else if and $config.enabled (not $config.storedType) }}
-            - name: configmap
+            {{- if $config.enabled }}
+            - name: {{ ternary "configmap" "configsecret" (ne $config.storedType "secret") }}
               mountPath: {{ $config.path }}
               subPath: {{ $name }}
             {{- end }}

--- a/charts/netdata/templates/secrets.yaml
+++ b/charts/netdata/templates/secrets.yaml
@@ -1,0 +1,50 @@
+{{- $secretParent := include "netdata.parent.configs.secret" . }}
+{{- if and .Values.parent.enabled $secretParent }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: netdata-conf-parent
+  labels:
+    app: {{ template "netdata.name" . }}
+    chart: {{ template "netdata.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  {{ $secretParent | indent 2 }}
+{{- end }}
+
+{{- $secretChild := include "netdata.child.configs.secret" . }}
+{{- if and .Values.child.enabled $secretChild}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: netdata-conf-child
+  labels:
+    app: {{ template "netdata.name" . }}
+    chart: {{ template "netdata.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  {{ $secretChild | indent 2 }}
+{{- end }}
+
+{{- $secretk8sState := include "netdata.k8sState.configs.secret" . }}
+{{- if and .Values.k8sState.enabled $secretk8sState }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: netdata-conf-k8s-state
+  labels:
+    app: {{ template "netdata.name" . }}
+    chart: {{ template "netdata.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  {{ $secretk8sState | indent 2 }}
+{{- end }}


### PR DESCRIPTION
To lift the security level it is good to store sensitive data inside the Kubernetes secret instead of configmaps. Each of the configurations can be customized by setting the `storedType:  secret`, by default it will be stored as a configmap when no specified. 

This change can help us to not expose any sensitive data like database credentials to users with the built-in `view` cluster roles which don't provide access to the Kubernetes secrets.