### PR TITLE
Remove /var/run/docker.sock mount

### DIFF
--- a/charts/netdata/templates/daemonset.yaml
+++ b/charts/netdata/templates/daemonset.yaml
@@ -154,7 +154,7 @@ spec:
               readOnly: true
               mountPath: /host/proc
             - name: run
-              mountPath: /var/run/docker.sock
+              mountPath: {{ .Values.child.volumes.run.path }}
             - name: sys
               mountPath: /host/sys
             - name: os-release
@@ -224,7 +224,7 @@ spec:
             path: /proc
         - name: run
           hostPath:
-            path: /var/run/docker.sock
+            path: {{ .Values.child.volumes.run.path }}
         - name: sys
           hostPath:
             path: /sys

--- a/charts/netdata/templates/daemonset.yaml
+++ b/charts/netdata/templates/daemonset.yaml
@@ -153,8 +153,6 @@ spec:
             - name: proc
               readOnly: true
               mountPath: /host/proc
-            - name: run
-              mountPath: {{ .Values.child.volumes.run.path }}
             - name: sys
               mountPath: /host/sys
             - name: os-release
@@ -222,9 +220,6 @@ spec:
         - name: proc
           hostPath:
             path: /proc
-        - name: run
-          hostPath:
-            path: {{ .Values.child.volumes.run.path }}
         - name: sys
           hostPath:
             path: /sys

--- a/charts/netdata/values.yaml
+++ b/charts/netdata/values.yaml
@@ -239,9 +239,6 @@ parent:
 child:
   enabled: true
   port: "{{ .Values.parent.port }}"
-  volumes:
-    run:
-      path: "/run/containerd/containerd.sock"
   updateStrategy: {}
     # type: RollingUpdate
     # rollingUpdate:

--- a/charts/netdata/values.yaml
+++ b/charts/netdata/values.yaml
@@ -239,7 +239,9 @@ parent:
 child:
   enabled: true
   port: "{{ .Values.parent.port }}"
-
+  volumes:
+    run:
+      path: "/run/containerd/containerd.sock"
   updateStrategy: {}
     # type: RollingUpdate
     # rollingUpdate:


### PR DESCRIPTION
Hi!

# Problem

In Kubernetes 1.24, dockershim and /var/run/docker.sock are deprecated in favor of CRI.

We have looked that netdata uses /var/run/docker.sock  to collect containers metadata, logs, and metrics  and is not possible to read it from helm values.


Please, give me your thoughts about it.
Thank you in advance.

Links related:
https://kubernetes.io/docs/tasks/administer-cluster/migrating-from-dockershim/
https://kubernetes.io/docs/tasks/administer-cluster/migrating-from-dockershim/migrating-telemetry-and-security-agents/
https://aws.amazon.com/es/blogs/containers/all-you-need-to-know-about-moving-to-containerd-on-amazon-eks/