### PR TITLE
bump sd image to v0.2.9

### DIFF
--- a/charts/netdata/values.yaml
+++ b/charts/netdata/values.yaml
@@ -12,7 +12,7 @@ image:
 sd:
   image:
     repository: netdata/agent-sd
-    tag: v0.2.8
+    tag: v0.2.9
     pullPolicy: Always
   child:
     enabled: true


### PR DESCRIPTION
Update service discovery to [v0.2.9](https://github.com/netdata/agent-service-discovery/releases/tag/v0.2.9).