### PR TITLE
New Chart version to 3.7.70

### DIFF
--- a/charts/netdata/Chart.yaml
+++ b/charts/netdata/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: netdata
-version: 3.7.69
+version: 3.7.70
 description: Real-time performance monitoring, done right!
 type: application
 keywords:

--- a/charts/netdata/README.md
+++ b/charts/netdata/README.md
@@ -2,7 +2,7 @@
 
 <a href="https://artifacthub.io/packages/search?repo=netdata" target="_blank" rel="noopener noreferrer"><img loading="lazy" src="https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/netdata" alt="Artifact HUB" class="img_node_modules-@docusaurus-theme-classic-lib-theme-MDXComponents-Img-styles-module"></img></a>
 
-<img src="https://img.shields.io/badge/Version-3.7.69-informational" alt="Version: 3.7.69"></img>
+<img src="https://img.shields.io/badge/Version-3.7.70-informational" alt="Version: 3.7.70"></img>
 
 <img loading="lazy" src="https://img.shields.io/badge/AppVersion-v1.42.3-informational" alt="AppVersion: v1.42.3" class="img_node_modules-@docusaurus-theme-classic-lib-theme-MDXComponents-Img-styles-module"></img>
 


### PR DESCRIPTION
Chart versioning workflow fails due to [this](https://github.com/netdata/helmchart/actions/runs/6119022233 ) workflow (initially executed 4 days ago) previously failing to bump the version in Chart.yaml, but having pushed the release tag for 3.7.70 

We seem to have a logical error in this workflow. Release tag shouldn't be pushed if workflow fails for whatever reason and version isn't updated in Chart.yaml.

Will add a task to fix this.