### PR TITLE
Delete uncommitted release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,12 +53,14 @@ jobs:
           git push
 
       - name: Delete release tag in case of version update commit failure
+        id: delete-tag
         if: steps.commit_version.outcome == 'failure'
         run: |
           git push origin --delete "netdata-${{ steps.new_version_var.outputs.new_version }}"
           git ls-remote --tags
 
       - name: Update Netdata Infra
+        if: steps.delete-tag.outcome == 'skipped'
         uses: benc-uk/workflow-dispatch@v1
         with:
           token: ${{ secrets.NETDATABOT_GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,7 @@ jobs:
         if: steps.commit_version.outcome == 'failure'
         run: |
           git push origin --delete "netdata-${{ steps.new_version_var.outputs.new_version }}"
+          git ls-remote --tags
 
       - name: Update Netdata Infra
         uses: benc-uk/workflow-dispatch@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,9 +46,16 @@ jobs:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Commit new version
+        id: commit_version
+        continue-on-error: true
         run: |
           git commit -am "[skip ci] New Chart version to ${{ steps.new_version_var.outputs.new_version }}"
           git push
+
+      - name: Delete release tag in case of version update commit failure
+        if: steps.commit_version.outcome == 'failure'
+        run: |
+          git push origin --delete "netdata-${{ steps.new_version_var.outputs.new_version }}"
 
       - name: Update Netdata Infra
         uses: benc-uk/workflow-dispatch@v1


### PR DESCRIPTION
Tag release step happens before committing the new version of the helmchart in Chart.yaml. This can lead to inconsistencies and cause following release actions to fail since "next" release tag has been pushed to remote but current_version on Chart.yaml is still the previous, so it always try to push an existing version.

This commit adds a check if commit step failed and deletes the previously pushed release tag

This way we can avoid cases where we have to manually edit Chart.yaml version as happened: https://github.com/netdata/helmchart/pull/386

ref: https://github.com/netdata/infra/issues/3820