### PR TITLE
empty tolerations for the k8sstate

### DIFF
--- a/charts/netdata/values.yaml
+++ b/charts/netdata/values.yaml
@@ -408,9 +408,7 @@ k8sState:
 
   nodeSelector: {}
 
-  tolerations:
-    - operator: Exists
-      effect: NoSchedule
+  tolerations: []
 
   affinity: {}
 


### PR DESCRIPTION
IMO setting the taint effect `NoSchedule` for the k8sState component is not required. Moreover during node upgrade, when you mark a selected node as unschedulable the pod with k8sState still can be scheduled on that node because of the taint and it slows down the upgrade process.