### PR TITLE
Issue https://github.com/netdata/helmchart/issues/402

### DIFF
--- a/charts/netdata/templates/daemonset.yaml
+++ b/charts/netdata/templates/daemonset.yaml
@@ -134,6 +134,7 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
+              host: 127.0.0.1
               path: /api/v1/info
               port: http
             initialDelaySeconds: {{ .Values.child.livenessProbe.initialDelaySeconds }}
@@ -143,6 +144,7 @@ spec:
             timeoutSeconds: {{ .Values.child.livenessProbe.timeoutSeconds }}
           readinessProbe:
             httpGet:
+              host: 127.0.0.1
               path: /api/v1/info
               port: http
             initialDelaySeconds: {{ .Values.child.readinessProbe.initialDelaySeconds }}

--- a/charts/netdata/values.yaml
+++ b/charts/netdata/values.yaml
@@ -300,6 +300,8 @@ child:
       enabled: true
       path: /etc/netdata/netdata.conf
       data: |
+        [web]
+          bind to = localhost:19999
         [db]
           mode = ram
         [health]


### PR DESCRIPTION
Bind Netdata child to localhost interfaces by default and fix livenessProbe and readinessProbe