### PR TITLE
fix links pointing to old go.d repo

### DIFF
--- a/charts/netdata/README.md
+++ b/charts/netdata/README.md
@@ -350,33 +350,33 @@ and exports them, so they can be monitored.
 
 Service discovery currently supports the following applications via their associated collector:
 
-- [ActiveMQ](https://github.com/netdata/go.d.plugin/blob/master/modules/activemq/README.md)
-- [Apache](https://github.com/netdata/go.d.plugin/blob/master/modules/apache/README.md)
-- [Bind](https://github.com/netdata/go.d.plugin/blob/master/modules/bind/README.md)
-- [CockroachDB](https://github.com/netdata/go.d.plugin/blob/master/modules/cockroachdb/README.md)
-- [Consul](https://github.com/netdata/go.d.plugin/blob/master/modules/consul/README.md)
-- [CoreDNS](https://github.com/netdata/go.d.plugin/blob/master/modules/coredns/README.md)
-- [Elasticsearch](https://github.com/netdata/go.d.plugin/blob/master/modules/elasticsearch/README.md)
-- [Fluentd](https://github.com/netdata/go.d.plugin/blob/master/modules/fluentd/README.md)
-- [FreeRADIUS](https://github.com/netdata/go.d.plugin/blob/master/modules/freeradius/README.md)
-- [HDFS](https://github.com/netdata/go.d.plugin/blob/master/modules/hdfs/README.md)
-- [Lighttpd](https://github.com/netdata/go.d.plugin/blob/master/modules/lighttpd/README.md)
-- [Logstash](https://github.com/netdata/go.d.plugin/blob/master/modules/logstash/README.md)
-- [MySQL](https://github.com/netdata/go.d.plugin/blob/master/modules/mysql/README.md)
-- [NGINX](https://github.com/netdata/go.d.plugin/blob/master/modules/nginx/README.md)
-- [OpenVPN](https://github.com/netdata/go.d.plugin/blob/master/modules/openvpn/README.md)
-- [PHP-FPM](https://github.com/netdata/go.d.plugin/blob/master/modules/phpfpm/README.md)
-- [RabbitMQ](https://github.com/netdata/go.d.plugin/blob/master/modules/rabbitmq/README.md)
-- [Solr](https://github.com/netdata/go.d.plugin/blob/master/modules/solr/README.md)
-- [Tengine](https://github.com/netdata/go.d.plugin/blob/master/modules/tengine/README.md)
-- [Unbound](https://github.com/netdata/go.d.plugin/blob/master/modules/unbound/README.md)
-- [VerneMQ](https://github.com/netdata/go.d.plugin/blob/master/modules/vernemq/README.md)
-- [ZooKeeper](https://github.com/netdata/go.d.plugin/blob/master/modules/zookeeper/README.md)
+- [ActiveMQ](https://github.com/netdata/netdata/blob/master/src/go/collectors/go.d.plugin/modules/activemq/README.md)
+- [Apache](https://github.com/netdata/netdata/blob/master/src/go/collectors/go.d.plugin/modules/apache/README.md)
+- [Bind](https://github.com/netdata/netdata/blob/master/src/go/collectors/go.d.plugin/modules/bind/README.md)
+- [CockroachDB](https://github.com/netdata/netdata/blob/master/src/go/collectors/go.d.plugin/modules/cockroachdb/README.md)
+- [Consul](https://github.com/netdata/netdata/blob/master/src/go/collectors/go.d.plugin/modules/consul/README.md)
+- [CoreDNS](https://github.com/netdata/netdata/blob/master/src/go/collectors/go.d.plugin/modules/coredns/README.md)
+- [Elasticsearch](https://github.com/netdata/netdata/blob/master/src/go/collectors/go.d.plugin/modules/elasticsearch/README.md)
+- [Fluentd](https://github.com/netdata/netdata/blob/master/src/go/collectors/go.d.plugin/modules/fluentd/README.md)
+- [FreeRADIUS](https://github.com/netdata/netdata/blob/master/src/go/collectors/go.d.plugin/modules/freeradius/README.md)
+- [HDFS](https://github.com/netdata/netdata/blob/master/src/go/collectors/go.d.plugin/modules/hdfs/README.md)
+- [Lighttpd](https://github.com/netdata/netdata/blob/master/src/go/collectors/go.d.plugin/modules/lighttpd/README.md)
+- [Logstash](https://github.com/netdata/netdata/blob/master/src/go/collectors/go.d.plugin/modules/logstash/README.md)
+- [MySQL](https://github.com/netdata/netdata/blob/master/src/go/collectors/go.d.plugin/modules/mysql/README.md)
+- [NGINX](https://github.com/netdata/netdata/blob/master/src/go/collectors/go.d.plugin/modules/nginx/README.md)
+- [OpenVPN](https://github.com/netdata/netdata/blob/master/src/go/collectors/go.d.plugin/modules/openvpn/README.md)
+- [PHP-FPM](https://github.com/netdata/netdata/blob/master/src/go/collectors/go.d.plugin/modules/phpfpm/README.md)
+- [RabbitMQ](https://github.com/netdata/netdata/blob/master/src/go/collectors/go.d.plugin/modules/rabbitmq/README.md)
+- [Solr](https://github.com/netdata/netdata/blob/master/src/go/collectors/go.d.plugin/modules/solr/README.md)
+- [Tengine](https://github.com/netdata/netdata/blob/master/src/go/collectors/go.d.plugin/modules/tengine/README.md)
+- [Unbound](https://github.com/netdata/netdata/blob/master/src/go/collectors/go.d.plugin/modules/unbound/README.md)
+- [VerneMQ](https://github.com/netdata/netdata/blob/master/src/go/collectors/go.d.plugin/modules/vernemq/README.md)
+- [ZooKeeper](https://github.com/netdata/netdata/blob/master/src/go/collectors/go.d.plugin/modules/zookeeper/README.md)
 
 #### Prometheus endpoints
 
 Service discovery supports Prometheus endpoints via
-the [Prometheus](https://github.com/netdata/go.d.plugin/blob/master/modules/prometheus/README.md) collector.
+the [Prometheus](https://github.com/netdata/netdata/blob/master/src/go/collectors/go.d.plugin/modules/prometheus/README.md) collector.
 
 Annotations on pods allow a fine control of the scraping process:
 


### PR DESCRIPTION
@ilyam8 this can be merged last and then you run ingest to get the change

dependent on https://github.com/netdata/netdata/pull/17005 and PRs listed inside to be merged