### PR TITLE
Allow to override the liveness and readiness probe host #402

### DIFF
--- a/charts/netdata/templates/child/daemonset.yaml
+++ b/charts/netdata/templates/child/daemonset.yaml
@@ -134,6 +134,7 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
+              host: {{ .Values.child.livenessProbe.httpGet.host }}
               path: /api/v1/info
               port: http
             initialDelaySeconds: {{ .Values.child.livenessProbe.initialDelaySeconds }}
@@ -143,6 +144,7 @@ spec:
             timeoutSeconds: {{ .Values.child.livenessProbe.timeoutSeconds }}
           readinessProbe:
             httpGet:
+              host: {{ .Values.child.readinessProbe.httpGet.host }}
               path: /api/v1/info
               port: http
             initialDelaySeconds: {{ .Values.child.readinessProbe.initialDelaySeconds }}

--- a/charts/netdata/values.yaml
+++ b/charts/netdata/values.yaml
@@ -252,12 +252,16 @@ child:
     #  memory: 4096Mi
 
   livenessProbe:
+    httpGet:
+      host: ""
     initialDelaySeconds: 0
     failureThreshold: 3
     periodSeconds: 30
     successThreshold: 1
     timeoutSeconds: 1
   readinessProbe:
+    httpGet:
+      host: ""
     initialDelaySeconds: 0
     failureThreshold: 3
     periodSeconds: 30


### PR DESCRIPTION
Since the child is running on network mode host, which by default also starts the web dashboard on port 19999 means running netdata on public worker nodes are exposed without authentication to the internet, especially when using different Kubernetes distributions which normally by default also not having any firewall on node ports configured.

As recommended by Netdata it's possible to bind the web port to a private IP or localhost, see https://learn.netdata.cloud/docs/netdata-agent/securing-netdata-agents/#expose-netdata-only-in-a-private-lan, the helm chart is not working at all because the readiness and liveness probes are using the public node IP by default (due to network mode host).

This partically fixes #402, at least allows to bind the web dashboard to 127.0.0.1 and bringing the pods online. If people are gonna manually patch the netdata.conf to disable the web panel it should be also possible to adjust the host value of these checks. 

Maybe also discuss setting the readiness and liveness probe to 127.0.0.1 by default, since it should also work when running netdata on all IPs (which is also default).