### PR TITLE
child: use 127.0.0.1 for httpGet probes if `hostNetwork` field is `true`

### DIFF
--- a/charts/netdata/templates/child/daemonset.yaml
+++ b/charts/netdata/templates/child/daemonset.yaml
@@ -134,7 +134,11 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
+            {{- if $.Values.child.livenessProbe.httpGet.host }}
               host: {{ .Values.child.livenessProbe.httpGet.host }}
+            {{- else if .Values.child.hostNetwork }}
+              host: 127.0.0.1
+            {{- end}}
               path: /api/v1/info
               port: http
             initialDelaySeconds: {{ .Values.child.livenessProbe.initialDelaySeconds }}
@@ -144,7 +148,11 @@ spec:
             timeoutSeconds: {{ .Values.child.livenessProbe.timeoutSeconds }}
           readinessProbe:
             httpGet:
+            {{- if $.Values.child.readinessProbe.httpGet.host }}
               host: {{ .Values.child.readinessProbe.httpGet.host }}
+            {{- else if .Values.child.hostNetwork }}
+              host: 127.0.0.1
+            {{- end}}
               path: /api/v1/info
               port: http
             initialDelaySeconds: {{ .Values.child.readinessProbe.initialDelaySeconds }}


### PR DESCRIPTION
As suggested in https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#http-probes

> Suppose the container listens on 127.0.0.1 and the Pod's hostNetwork field is true. Then host, under httpGet, should be set to 127.0.0.1. 

cc @BirknerAlex