### PR TITLE
rm service discovery sidecar for Netdata v2.2+

### DIFF
--- a/charts/netdata/sdconfig/k8s.yml
+++ b/charts/netdata/sdconfig/k8s.yml
@@ -1,0 +1,242 @@
+disabled: no
+
+name: 'kubernetes'
+
+discover:
+  - discoverer: k8s
+    k8s:
+      - tags: unknown
+        role: pod
+        pod:
+          local_mode: yes
+classify:
+  - name: "Control-Plane"
+    selector: unknown
+    tags: -unknown control_plane
+    match:
+      - tags: kube_scheduler
+        expr: '{{ glob .Image "k8s.gcr.io/kube-scheduler:*" }}'
+      - tags: kube_controller_manager
+        expr: '{{ glob .Image "k8s.gcr.io/kube-controller-manager:*" }}'
+  - name: "Applications"
+    selector: unknown
+    tags: -unknown applications
+    match:
+      - tags: activemq
+        expr: '{{ and (eq .Port "8161") (glob .Image "*/activemq*") }}'
+      - tags: apache
+        expr: '{{ and (eq .Port "80" "8080") (glob .Image "httpd*" "*/httpd*") }}'
+      - tags: bind
+        expr: '{{ and (eq .Port "8653") (glob .Image "*/bind*") }}'
+      - tags: cockroachdb
+        expr: '{{ and (eq .Port "8080") (glob .Image "*/cockroach*") }}'
+      - tags: consul
+        expr: '{{ and (eq .Port "8500") (glob .Image "consul*" "*/consul*") }}'
+      - tags: coredns
+        expr: '{{ and (eq .Port "9153") (glob .Image "*/coredns*") }}'
+      - tags: elasticsearch
+        expr: '{{ and (eq .Port "9200") (glob .Image "elasticsearch:*" "*/elasticsearch:*") }}'
+      - tags: fluentd
+        expr: '{{ and (eq .Port "24220") (glob .Image "fluentd*" "*/fluentd*") }}'
+      - tags: freeradius
+        expr: '{{ and (eq .Port "18121") (glob .Image "*/freeradius*") }}'
+      - tags: hdfs
+        expr: '{{ and (eq .Port "50070") (glob .Image "*/hdfs*") }}'
+      - tags: lighttpd
+        expr: '{{ and (eq .Port "80" "8080") (glob .Image "*/lighttpd*") }}'
+      - tags: logstash
+        expr: '{{ and (eq .Port "9600") (glob .Image "logstash*" "*/logstash*") }}'
+      - tags: mysql
+        expr: '{{ and (eq .Port "3306") (glob .Image "mysql*" "*/mysql*" "mariadb*" "*/mariadb*") }}'
+      - tags: nginx
+        expr: '{{ and (eq .Port "80" "8080") (glob .Image "nginx*" "*/nginx*") }}'
+      - tags: openvpn
+        expr: '{{ and (eq .Port "7505") (glob .Image "*/openvpn") }}'
+      - tags: phpfpm
+        expr: '{{ and (eq .Port "80" "8080") (glob .Image "*/phpfpm*" "*/php-fpm*") }}'
+      - tags: rabbitmq
+        expr: '{{ and (eq .Port "15672") (glob .Image "rabbitmq*" "*/rabbitmq*") }}'
+      - tags: solr
+        expr: '{{ and (eq .Port "8983") (glob .Image "solr*" "*/solr*") }}'
+      - tags: tengine
+        expr: '{{ and (eq .Port "80" "8080") (glob .Image "*/tengine*") }}'
+      - tags: unbound
+        expr: '{{ and (eq .Port "8953") (glob .Image "*/unbound*") }}'
+      - tags: vernemq
+        expr: '{{ and (eq .Port "8888") (glob .Image "*/vernemq*") }}'
+      - tags: zookeeper
+        expr: '{{ and (eq .Port "2181") (glob .Image "zookeeper*" "*/zookeeper*") }}'
+      - tags: consul_envoy
+        expr: |
+          {{ $imageOK := glob .Image "*/consul-dataplane*" -}}
+          {{ $scrapeOK := eq (get .Annotations "prometheus.io/scrape") "true" -}}
+          {{ $promPort := get .Annotations "prometheus.io/port" -}}
+          {{ $portOK1 := and (eq .Port $promPort) (not (empty .Port)) -}}
+          {{ $portOK2 := and (empty .Port) (not (empty $promPort)) -}}
+          {{ and $imageOK $scrapeOK (or $portOK1 $portOK2) }}
+  - name: "Prometheus Generic Applications"
+    selector: unknown
+    tags: -unknown prometheus_generic
+    match:
+      - tags: prometheus_generic
+        expr: |
+          {{ $scrapeOK := eq (get .Annotations "prometheus.io/scrape") "true" -}}
+          {{ $portOK := eq (default .Port (get .Annotations "prometheus.io/port")) .Port -}}
+          {{ $imageOK := not (glob .Image "netdata/netdata*" "*pulsar*" "*telegraf*") -}}
+          {{ and $scrapeOK $portOK $imageOK }}
+compose:
+  - name: "Control-Plane"
+    selector: '!unknown control_plane'
+    config:
+      - selector: kube_scheduler
+        template: |
+          - module: prometheus
+            name: prometheus-{{.TUID}}
+            url: http://{{.PodIP}}:{{default "10251" .Port}}/metrics
+            app: '{{.ContName}}'
+            update_every: 10
+            max_time_series: 1000
+      - selector: kube_controller_manager
+        template: |
+          - module: prometheus
+            name: prometheus-{{.TUID}}
+            url: http://{{.PodIP}}:{{default "10252" .Port}}/metrics
+            app: '{{.ContName}}'
+            update_every: 10
+            max_time_series: 2000
+  - name: "Prometheus Generic Applications"
+    selector: '!unknown prometheus_generic'
+    config:
+      - selector: prometheus_generic
+        template: |
+          {{ $path := default "/metrics" (get .Annotations "prometheus.io/path") -}}
+          - module: prometheus
+            name: prometheus-{{.TUID}}
+            url: http://{{.Address}}{{$path}}
+            app: '{{.ContName}}'
+            update_every: 10
+            max_time_series: 4000
+  - name: "Applications"
+    selector: '!unknown applications'
+    tags: file
+    config:
+      - selector: activemq
+        template: |
+          - module: activemq
+            name: activemq-{{.TUID}}
+            url: http://{{.Address}}
+      - selector: apache
+        template: |
+          - module: apache
+            name: apache-{{.TUID}}
+            url: http://{{.Address}}/server-status?auto
+      - selector: bind
+        template: |
+          - module: bind
+            name: bind-{{.TUID}}
+            url: http://{{.Address}}/json/v1
+      - selector: cockroachdb
+        template: |
+          - module: cockroachdb
+            name: cockroachdb-{{.TUID}}
+            url: http://{{.Address}}/_status/vars
+      - selector: consul
+        template: |
+          - module: consul
+            name: consul-{{.TUID}}
+            url: http://{{.Address}}
+      - selector: coredns
+        template: |
+          - module: coredns
+            name: coredns-{{.TUID}}
+            url: http://{{.Address}}/metrics
+      - selector: elasticsearch
+        template: |
+          - module: elasticsearch
+            name: elasticsearch-{{.TUID}}
+            url: http://{{.Address}}
+      - selector: consul_envoy
+        template: |
+          {{ $path := default "/metrics" (get .Annotations "prometheus.io/path") -}}
+          {{ $promPort := get .Annotations "prometheus.io/port" -}}
+          {{ $port := ternary .Port $promPort (not (empty .Port)) -}}
+          - module: envoy
+            name: {{.TUID}}
+            url: http://{{ .PodIP }}:{{ $port }}{{ $path }}
+      - selector: fluentd
+        template: |
+          - module: fluentd
+            name: fluentd-{{.TUID}}
+            url: http://{{.Address}}
+      - selector: freeradius
+        template: |
+          - module: freeradius
+            name: freeradius-{{.TUID}}
+            address: {{.PodIP}}
+            port: {{.Port}}
+      - selector: hdfs
+        template: |
+          - module: hdfs
+            name: hdfs-{{.TUID}}
+            url: http://{{.Address}}/jmx
+      - selector: lighttpd
+        template: |
+          - module: lighttpd
+            name: lighttpd-{{.TUID}}
+            url: http://{{.Address}}/server-status?auto
+      - selector: logstash
+        template: |
+          - module: logstash
+            name: logstash-{{.TUID}}
+            url: http://{{.Address}}
+      - selector: mysql
+        template: |
+          - module: mysql
+            name: mysql-{{.TUID}}
+            dsn: 'netdata@tcp({{.Address}})/'
+      - selector: nginx
+        template: |
+          - module: nginx
+            name: nginx-{{.TUID}}
+            url: http://{{.Address}}/stub_status
+      - selector: openvpn
+        template: |
+          - module: openvpn
+            name: openvpn-{{.TUID}}
+            address: {{.Address}}
+      - selector: phpfpm
+        template: |
+          - module: phpfpm
+            name: phpfpm-{{.TUID}}
+            url: http://{{.Address}}/status?full&json
+      - selector: rabbitmq
+        template: |
+          - module: rabbitmq
+            name: rabbitmq-{{.TUID}}
+            url: http://{{.Address}}
+      - selector: solr
+        template: |
+          - module: solr
+            name: solr-{{.TUID}}
+            url: http://{{.Address}}
+      - selector: tengine
+        template: |
+          - module: tengine
+            name: tengine-{{.TUID}}
+            url: http://{{.Address}}/us
+      - selector: unbound
+        template: |
+          - module: unbound
+            name: unbound-{{.TUID}}
+            address: {{.Address}}
+            use_tls: false
+      - selector: vernemq
+        template: |
+          - module: vernemq
+            name: vernemq-{{.TUID}}
+            url: http://{{.Address}}/metrics
+      - selector: zookeeper
+        template: |
+          - module: zookeeper
+            name: zookeeper-{{.TUID}}
+            address: {{.Address}}

--- a/charts/netdata/templates/_helpers.tpl
+++ b/charts/netdata/templates/_helpers.tpl
@@ -41,8 +41,8 @@ Return the target Kubernetes version
 {{/*
 The function determines if the Netdata version is less than 3.0-0.
 */}}
-{{- define "netdata.verLess3" -}}
-{{- if semverCompare "<3.0-0" .Chart.AppVersion -}}
+{{- define "netdata.verLess22" -}}
+{{- if semverCompare "<2.2-0" .Chart.AppVersion -}}
 {{- "true" -}}
 {{- else -}}
 {{- "" -}}

--- a/charts/netdata/templates/_helpers.tpl
+++ b/charts/netdata/templates/_helpers.tpl
@@ -39,6 +39,17 @@ Return the target Kubernetes version
 {{- end -}}
 
 {{/*
+The function determines if the Netdata version is less than 3.0-0.
+*/}}
+{{- define "netdata.verLess3" -}}
+{{- if semverCompare "<3.0-0" .Chart.AppVersion -}}
+{{- "true" -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the appropriate apiVersion for ingress.
 */}}
 {{- define "netdata.ingress.apiVersion" -}}

--- a/charts/netdata/templates/child/configmap.yaml
+++ b/charts/netdata/templates/child/configmap.yaml
@@ -35,7 +35,12 @@ data:
       {{- else if .value }}
         {{- toYaml .value | nindent 4 }}
       {{- else }}
-        {{- $.Files.Get .file | nindent 4 }}
+        {{- if .file }}
+          {{- $.Files.Get .file | nindent 4 }}
+        {{- else }}
+          {{- $configFile := ternary "sdconfig/child.yml" "sdconfig/k8s.yml" (eq (include "netdata.verLess3" $) "true") }}
+          {{- $.Files.Get $configFile | nindent 4 }}
+        {{- end }}
       {{- end}}
     {{- end}}
 {{- end }}

--- a/charts/netdata/templates/child/configmap.yaml
+++ b/charts/netdata/templates/child/configmap.yaml
@@ -38,7 +38,7 @@ data:
         {{- if .file }}
           {{- $.Files.Get .file | nindent 4 }}
         {{- else }}
-          {{- $configFile := ternary "sdconfig/child.yml" "sdconfig/k8s.yml" (eq (include "netdata.verLess3" $) "true") }}
+          {{- $configFile := ternary "sdconfig/child.yml" "sdconfig/k8s.yml" (eq (include "netdata.verLess22" $) "true") }}
           {{- $.Files.Get $configFile | nindent 4 }}
         {{- end }}
       {{- end}}

--- a/charts/netdata/templates/child/daemonset.yaml
+++ b/charts/netdata/templates/child/daemonset.yaml
@@ -111,8 +111,10 @@ spec:
             - name: NETDATA_LISTENER_PORT
               value: '{{ tpl (.Values.child.port | toString) . }}'
             {{- if .Values.sd.child.enabled }}
+            {{- if include "netdata.verLess3" . }}
             - name: NETDATA_PLUGINS_GOD_WATCH_PATH
               value: "/etc/netdata/go.d/sd/go.d.yml"
+            {{- end }}
             {{- end }}
             {{- range $key, $value := .Values.child.env }}
             - name: {{ $key }}
@@ -174,8 +176,14 @@ spec:
               mountPath: /var/lib/netdata
             {{- end }}
             {{- if .Values.sd.child.enabled }}
+            {{- if include "netdata.verLess3" . }}
             - name: sd-shared
               mountPath: "/etc/netdata/go.d/sd/"
+            {{- else }}
+            - name: sdconfigmap
+              mountPath: "/etc/netdata/go.d/sd/k8s.conf"
+              subPath: {{ .Values.sd.child.configmap.key }}
+            {{- end }}
             {{- end }}
             {{- if .Values.child.extraVolumeMounts -}}
 {{ toYaml .Values.child.extraVolumeMounts | nindent 12 }}
@@ -188,6 +196,7 @@ spec:
           resources:
 {{ toYaml .Values.child.resources | indent 12 }}
         {{- if .Values.sd.child.enabled }}
+        {{- if include "netdata.verLess3" . }}
         - name: sd
           image: "{{ .Values.sd.image.repository }}:{{ .Values.sd.image.tag }}"
           imagePullPolicy: {{ .Values.sd.image.pullPolicy }}
@@ -207,6 +216,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+        {{- end }}
         {{- end }}
     {{- with .Values.child.nodeSelector }}
       nodeSelector:
@@ -251,8 +261,15 @@ spec:
         {{- end }}
         {{- end }}
         {{- if .Values.sd.child.enabled }}
+        {{- if include "netdata.verLess3" . }}
         - name: sd-shared
           emptyDir: { }
+        {{- else }}
+        - name: sdconfigmap
+          configMap:
+            name: {{ .Values.sd.child.configmap.name }}
+            optional: true
+        {{- end }}
         {{- end }}
         {{- if .Values.child.extraVolumes }}
 {{ toYaml .Values.child.extraVolumes | indent 8}}

--- a/charts/netdata/templates/child/daemonset.yaml
+++ b/charts/netdata/templates/child/daemonset.yaml
@@ -111,7 +111,7 @@ spec:
             - name: NETDATA_LISTENER_PORT
               value: '{{ tpl (.Values.child.port | toString) . }}'
             {{- if .Values.sd.child.enabled }}
-            {{- if include "netdata.verLess3" . }}
+            {{- if include "netdata.verLess22" . }}
             - name: NETDATA_PLUGINS_GOD_WATCH_PATH
               value: "/etc/netdata/go.d/sd/go.d.yml"
             {{- end }}
@@ -176,7 +176,7 @@ spec:
               mountPath: /var/lib/netdata
             {{- end }}
             {{- if .Values.sd.child.enabled }}
-            {{- if include "netdata.verLess3" . }}
+            {{- if include "netdata.verLess22" . }}
             - name: sd-shared
               mountPath: "/etc/netdata/go.d/sd/"
             {{- else }}
@@ -196,7 +196,7 @@ spec:
           resources:
 {{ toYaml .Values.child.resources | indent 12 }}
         {{- if .Values.sd.child.enabled }}
-        {{- if include "netdata.verLess3" . }}
+        {{- if include "netdata.verLess22" . }}
         - name: sd
           image: "{{ .Values.sd.image.repository }}:{{ .Values.sd.image.tag }}"
           imagePullPolicy: {{ .Values.sd.image.pullPolicy }}
@@ -261,7 +261,7 @@ spec:
         {{- end }}
         {{- end }}
         {{- if .Values.sd.child.enabled }}
-        {{- if include "netdata.verLess3" . }}
+        {{- if include "netdata.verLess22" . }}
         - name: sd-shared
           emptyDir: { }
         {{- else }}

--- a/charts/netdata/values.yaml
+++ b/charts/netdata/values.yaml
@@ -21,7 +21,7 @@ sd:
       key: config.yml
       # if 'from' is {} the ConfigMap is not generated
       from:
-        file: sdconfig/child.yml
+        file: ""
         value: {}
     resources:
       limits:


### PR DESCRIPTION
[service-discovery sidecar](https://github.com/netdata/agent-service-discovery) is no longer needed as its functionality is built into go.d.plugin.

This change was announced in [v2.1.0 deprecation notice](https://github.com/netdata/netdata/releases/tag/v2.1.0#v210-deprecation-notice).