### PR TITLE
ci: bump setup-python version to 3.13

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-python@v5.3.0
         with:
-          python-version: 3.7
+          python-version: 3.13
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.6.1


### PR DESCRIPTION
Fixes (#462)

```
Run actions/setup-python@v5.3.0
Installed versions
  Version 3.7 was not found in the local cache
  Error: The version '3.7' with architecture 'x64' was not found for Ubuntu 24.04.
  The list of all available versions can be found he
```