### PR TITLE
Add Startup Volume Permission Enforcement

### DIFF
--- a/charts/netdata/templates/parent/deployment.yaml
+++ b/charts/netdata/templates/parent/deployment.yaml
@@ -60,7 +60,7 @@ spec:
       {{- end }}
       {{- if .Values.parent.volumePermissions.enabled }}
       {{- with .Values.parent.volumePermissions }}
-        - name: volumePermissions
+        - name: volume-permissions
           image: "{{ .image.repository }}:{{ .image.tag }}"
           imagePullPolicy: {{ .image.pullPolicy }}
           securityContext:

--- a/charts/netdata/templates/parent/deployment.yaml
+++ b/charts/netdata/templates/parent/deployment.yaml
@@ -58,45 +58,7 @@ spec:
           resources:
 {{ toYaml .Values.sysctlInitContainer.resources | indent 12 }}
       {{- end }}
-      {{- if .Values.parent.volumePermissions.enabled }}
-      {{- with .Values.parent.volumePermissions }}
-        - name: volume-permissions
-          image: "{{ .image.repository }}:{{ .image.tag }}"
-          imagePullPolicy: {{ .image.pullPolicy }}
-          securityContext:
-            runAsNonRoot: false
-            privileged: true
-            runAsUser: 0
-          command:
-          - /bin/sh
-          - -ec
-          - |
-            {{- if $.Values.parent.database.persistence }}
-            chown {{ $.Values.parent.securityContext.runAsUser }}:{{ $.Values.parent.securityContext.runAsGroup }} /var/cache/netdata
-            {{- end }}
-            {{- if $.Values.parent.alarms.persistence }}
-            chown {{ $.Values.parent.securityContext.runAsUser }}:{{ $.Values.parent.securityContext.runAsGroup }} /var/lib/netdata
-            {{- end }}
-          resources:
-{{ toYaml .resources | indent 12}}
-          volumeMounts:
-            {{- range $name, $config := $.Values.parent.configs }}
-            {{- if $config.enabled }}
-            - name: {{ ternary "configmap" "configsecret" (ne $config.storedType "secret") }}
-              mountPath: {{ $config.path }}
-              subPath: {{ $name }}
-            {{- end }}
-            {{- end }}
-            {{- if $.Values.parent.database.persistence }}
-            - name: database
-              mountPath: /var/cache/netdata
-            {{- end }}
-            {{- if $.Values.parent.alarms.persistence }}
-            - name: alarms
-              mountPath: /var/lib/netdata
-            {{- end }}
-      {{- end }}
-      {{- end }}
+{{ toYaml .Values.parent.extraInitContainers | indent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ tpl .Values.image.tag . }}"

--- a/charts/netdata/templates/parent/deployment.yaml
+++ b/charts/netdata/templates/parent/deployment.yaml
@@ -71,10 +71,10 @@ spec:
           - /bin/sh
           - -ec
           - |
-            {{- if .database.persistence }}
+            {{- if $.Values.parent.database.persistence }}
             chown {{ $.Values.parent.securityContext.runAsUser }}:{{ $.Values.parent.securityContext.runAsGroup }} /var/cache/netdata
             {{- end }}
-            {{- if .alarms.persistence }}
+            {{- if $.Values.parent.alarms.persistence }}
             chown {{ $.Values.parent.securityContext.runAsUser }}:{{ $.Values.parent.securityContext.runAsGroup }} /var/lib/netdata
             {{- end }}
           resources:

--- a/charts/netdata/templates/parent/deployment.yaml
+++ b/charts/netdata/templates/parent/deployment.yaml
@@ -35,7 +35,7 @@ spec:
 {{- end }}
     spec:
       securityContext:
-        fsGroup: 201
+        fsGroup: {{ .Values.parent.securityContext.fsGroup }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
       {{- if .Values.parent.priorityClassName }}
       priorityClassName: "{{ .Values.parent.priorityClassName }}"
@@ -57,6 +57,45 @@ spec:
             runAsUser: 0
           resources:
 {{ toYaml .Values.sysctlInitContainer.resources | indent 12 }}
+      {{- end }}
+      {{- if .Values.parent.volumePermissions.enabled }}
+      {{- with .Values.parent.volumePermissions }}
+        - name: volumePermissions
+          image: "{{ .image.repository }}:{{ .image.tag }}"
+          imagePullPolicy: {{ .image.pullPolicy }}
+          securityContext:
+            runAsNonRoot: false
+            privileged: true
+            runAsUser: 0
+          command:
+          - /bin/sh
+          - -ec
+          - |
+            {{- if .database.persistence }}
+            chown {{ $.Values.parent.securityContext.runAsUser }}:{{ $.Values.parent.securityContext.runAsGroup }} /var/cache/netdata
+            {{- end }}
+            {{- if .alarms.persistence }}
+            chown {{ $.Values.parent.securityContext.runAsUser }}:{{ $.Values.parent.securityContext.runAsGroup }} /var/lib/netdata
+            {{- end }}
+          resources:
+{{ toYaml .resources | indent 12}}
+          volumeMounts:
+            {{- range $name, $config := .Values.parent.configs }}
+            {{- if $config.enabled }}
+            - name: {{ ternary "configmap" "configsecret" (ne $config.storedType "secret") }}
+              mountPath: {{ $config.path }}
+              subPath: {{ $name }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.parent.database.persistence }}
+            - name: database
+              mountPath: /var/cache/netdata
+            {{- end }}
+            {{- if .Values.parent.alarms.persistence }}
+            - name: alarms
+              mountPath: /var/lib/netdata
+            {{- end }}
+      {{- end }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
@@ -117,6 +156,9 @@ spec:
             periodSeconds: {{ .Values.parent.readinessProbe.periodSeconds }}
             successThreshold: {{ .Values.parent.readinessProbe.successThreshold }}
             timeoutSeconds: {{ .Values.parent.readinessProbe.timeoutSeconds }}
+          securityContext:
+            runAsUser: {{ .Values.parent.securityContext.runAsUser }}
+            runAsGroup: {{ .Values.parent.securityContext.runAsGroup }}
           volumeMounts:
             - name: os-release
               mountPath: /host/etc/os-release

--- a/charts/netdata/templates/parent/deployment.yaml
+++ b/charts/netdata/templates/parent/deployment.yaml
@@ -80,18 +80,18 @@ spec:
           resources:
 {{ toYaml .resources | indent 12}}
           volumeMounts:
-            {{- range $name, $config := .Values.parent.configs }}
+            {{- range $name, $config := $.Values.parent.configs }}
             {{- if $config.enabled }}
             - name: {{ ternary "configmap" "configsecret" (ne $config.storedType "secret") }}
               mountPath: {{ $config.path }}
               subPath: {{ $name }}
             {{- end }}
             {{- end }}
-            {{- if .Values.parent.database.persistence }}
+            {{- if $.Values.parent.database.persistence }}
             - name: database
               mountPath: /var/cache/netdata
             {{- end }}
-            {{- if .Values.parent.alarms.persistence }}
+            {{- if $.Values.parent.alarms.persistence }}
             - name: alarms
               mountPath: /var/lib/netdata
             {{- end }}

--- a/charts/netdata/values.yaml
+++ b/charts/netdata/values.yaml
@@ -62,7 +62,7 @@ ingress:
   path: /
   pathType: Prefix
   hosts:
-    - netdata.k8s.local
+  - netdata.k8s.local
   ## whole spec is going to be included into ingress spec.
   ## if you intend to use ingressClassName declaration, remove ingress.class from annotations
   # spec:
@@ -129,6 +129,23 @@ parent:
     periodSeconds: 30
     successThreshold: 1
     timeoutSeconds: 1
+  securityContext:
+    runAsUser: 201
+    runAsGroup: 201
+    fsGroup: 201
+  volumePermissions:
+    enabled: false
+    image:
+      repository: bitnami/os-shell
+      tag: 12-debian-12-r41
+      pullPolicy: IfNotPresent
+    resources:
+      limits:
+        cpu: 500m
+        memory: 200Mi
+      requests:
+        cpu: 100m
+        memory: 100Mi
 
   terminationGracePeriodSeconds: 300
 
@@ -270,8 +287,8 @@ child:
   nodeSelector: {}
 
   tolerations:
-    - operator: Exists
-      effect: NoSchedule
+  - operator: Exists
+    effect: NoSchedule
 
   affinity: {}
 

--- a/charts/netdata/values.yaml
+++ b/charts/netdata/values.yaml
@@ -133,19 +133,6 @@ parent:
     runAsUser: 201
     runAsGroup: 201
     fsGroup: 201
-  volumePermissions:
-    enabled: false
-    image:
-      repository: bitnami/os-shell
-      tag: 12-debian-12-r41
-      pullPolicy: IfNotPresent
-    resources:
-      limits:
-        cpu: 500m
-        memory: 200Mi
-      requests:
-        cpu: 100m
-        memory: 100Mi
 
   terminationGracePeriodSeconds: 300
 
@@ -252,6 +239,8 @@ parent:
   extraVolumeMounts: []
 
   extraVolumes: []
+
+  extraInitContainers: []
 
 child:
   enabled: true


### PR DESCRIPTION
Resolves #449 . This ads the ability run the parent pod as a select uid/gid, and run an init container that will set file permissions appropriately on the mounted directories.