### PR TITLE
deduplicate kubelet/kubeproxy metrics collection

### DIFF
--- a/charts/netdata/values.yaml
+++ b/charts/netdata/values.yaml
@@ -345,8 +345,10 @@ child:
         update_every: 1
         autodetection_retry: 0
         jobs:
-          - url: http://127.0.0.1:10255/metrics
-          - url: https://localhost:10250/metrics
+          - name: local
+            url: http://127.0.0.1:10255/metrics
+          - name: local
+            url: https://localhost:10250/metrics
             tls_skip_verify: yes
     kubeproxy:
       enabled: true
@@ -355,7 +357,8 @@ child:
         update_every: 1
         autodetection_retry: 0
         jobs:
-          - url: http://127.0.0.1:10249/metrics
+          - name: local
+            url: http://127.0.0.1:10249/metrics
 
   env: {}
     ## To disable anonymous statistics:


### PR DESCRIPTION
This PR fixes duplicate metrics collection from kubelet by aligning the static job names in our Helm chart with the dynamic job names used by the [locallisteners discoverer](https://github.com/netdata/netdata/blob/2db34d2af56468b009c1bf4de6989fc09298f93c/src/go/plugin/go.d/config/go.d/sd/net_listeners.conf#L345-L354).

We were collecting metrics from kubelet twice:

- Once through the static k8s_kubelet job defined in our Helm chart
- Once through the dynamic local job discovered by the locallisteners discoverer

Both jobs were running simultaneously because they had different names, resulting in duplicate metrics.