### PR TITLE
Add missing otel signal viewer plugin for the otel Agent

### DIFF
--- a/charts/netdata/values.yaml
+++ b/charts/netdata/values.yaml
@@ -1040,6 +1040,7 @@ netdataOpentelemetry:
           cgroups = no
           enable running new plugins = no
           otel = yes
+          otel-signal-viewer = yes
           journal-viewer = yes
           slabinfo = no
           perf = no


### PR DESCRIPTION
As the default configuration explicitly disables "new" plugins, all plugins that are not explicitly enabled will be disabled. Since the set of enabled plugins for use within k8s has been created a while ago, new plugins such as the `otel-signal-viewer` plugin are not mentioned, even though we do expect them to be there.
