### PR TITLE
feat(serviceAccount): support custom annotations on the service account

### DIFF
--- a/charts/netdata/README.md
+++ b/charts/netdata/README.md
@@ -459,6 +459,15 @@ true
 			<td>The name of the service account to use. If not set and create is true, a name is generated using the fullname template</td>
 		</tr>
 		<tr>
+			<td>serviceAccount.annotations</td>
+			<td>object</td>
+			<td><pre lang="json">
+{}
+</pre>
+</td>
+			<td>Annotations to add to the service account (e.g. an AWS IRSA `eks.amazonaws.com/role-arn`)</td>
+		</tr>
+		<tr>
 			<td>restarter.enabled</td>
 			<td>bool</td>
 			<td><pre lang="json">

--- a/charts/netdata/templates/serviceaccount.yaml
+++ b/charts/netdata/templates/serviceaccount.yaml
@@ -10,4 +10,8 @@ metadata:
     heritage: {{ .Release.Service }}
   name: {{ .Values.serviceAccount.name }}
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end -}}

--- a/charts/netdata/values.yaml
+++ b/charts/netdata/values.yaml
@@ -174,6 +174,9 @@ serviceAccount:
   # -- The name of the service account to use. If not set and create is true, a name is generated using the fullname template
   # @section -- General settings
   name: netdata
+  # -- Annotations to add to the service account (e.g. an AWS IRSA `eks.amazonaws.com/role-arn`)
+  # @section -- General settings
+  annotations: {}
 
 restarter:
   # -- Install CronJob to update Netdata Pods


### PR DESCRIPTION
Add a serviceAccount.annotations value and render it onto the ServiceAccount metadata. Enables setting annotations natively (e.g. an AWS IRSA eks.amazonaws.com/role-arn) instead of patching the chart-created SA after install. Defaults to {} so existing releases are unaffected.