### PR TITLE
docs: replace retired community category link

### DIFF
--- a/charts/netdata/README.md
+++ b/charts/netdata/README.md
@@ -2544,4 +2544,4 @@ If you want to contribute, we're humbled!
 - Take a look at our [Contributing Guidelines](https://github.com/netdata/.github/blob/main/CONTRIBUTING.md).
 - This repository is under the [Netdata Code Of Conduct](https://github.com/netdata/.github/blob/main/CODE_OF_CONDUCT.md).
 - Chat about your contribution and let us help you in
-  our [forum](https://community.netdata.cloud/c/agent-development/9)!
+  our [forum](https://community.netdata.cloud/)!

--- a/templates/netdata-README.md.gotmpl
+++ b/templates/netdata-README.md.gotmpl
@@ -443,4 +443,4 @@ If you want to contribute, we're humbled!
 - Take a look at our [Contributing Guidelines](https://github.com/netdata/.github/blob/main/CONTRIBUTING.md).
 - This repository is under the [Netdata Code Of Conduct](https://github.com/netdata/.github/blob/main/CODE_OF_CONDUCT.md).
 - Chat about your contribution and let us help you in
-  our [forum](https://community.netdata.cloud/c/agent-development/9)!
+  our [forum](https://community.netdata.cloud/)!


### PR DESCRIPTION
## Summary

- replace the deleted Agent Development forum category with the active Netdata Community root
- update both the Helm README template and its generated chart README

## Why

The deleted category is ingested into Learn and renders as a broken cross-site link. Updating the authoritative Helm template prevents documentation regeneration from restoring it.

## Compatibility

Documentation only. Chart behavior and values are unchanged.

## Validation

- `curl --location --head https://community.netdata.cloud/` — HTTP 200
- `./generate-documentation.sh` with the workflow-pinned `helm-docs@v1.14.2`
- `git diff --check`