### PR TITLE
docs: replace retired community forum link

### DIFF
--- a/charts/netdata/README.md
+++ b/charts/netdata/README.md
@@ -2544,4 +2544,4 @@ If you want to contribute, we're humbled!
 - Take a look at our [Contributing Guidelines](https://github.com/netdata/.github/blob/main/CONTRIBUTING.md).
 - This repository is under the [Netdata Code Of Conduct](https://github.com/netdata/.github/blob/main/CODE_OF_CONDUCT.md).
 - Chat about your contribution and let us help you in
-  our [forum](https://community.netdata.cloud/c/agent-development/9)!
+  our [forum](https://community.netdata.cloud/)!

--- a/templates/netdata-README.md.gotmpl
+++ b/templates/netdata-README.md.gotmpl
@@ -443,4 +443,4 @@ If you want to contribute, we're humbled!
 - Take a look at our [Contributing Guidelines](https://github.com/netdata/.github/blob/main/CONTRIBUTING.md).
 - This repository is under the [Netdata Code Of Conduct](https://github.com/netdata/.github/blob/main/CODE_OF_CONDUCT.md).
 - Chat about your contribution and let us help you in
-  our [forum](https://community.netdata.cloud/c/agent-development/9)!
+  our [forum](https://community.netdata.cloud/)!


### PR DESCRIPTION
## Purpose

Repair the broken community link published in the Helm chart reference and ingested by Learn.

## Resulting behavior

- Replaces the retired Agent Development category URL with the current community forum root.
- Updates both the source template and generated chart README.

## Validation

- Regenerated the README with helm-docs v1.14.2, matching repository CI.
- The generated output has no additional differences.
- The replacement URL returns HTTP 200.